### PR TITLE
Preserve message block types during serialization

### DIFF
--- a/app/src/test/java/com/labteto/dshmobile/data/FrameParserTest.kt
+++ b/app/src/test/java/com/labteto/dshmobile/data/FrameParserTest.kt
@@ -1,0 +1,22 @@
+package com.labteto.dshmobile.data
+
+import com.labteto.dshmobile.core.session.AssistantMessageNode
+import com.labteto.dshmobile.core.session.EventFold
+import com.labteto.dshmobile.core.wire.decodeFromString
+import com.labteto.dshmobile.core.wire.dto.SessionEvent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FrameParserTest {
+    @Test
+    fun `production envelope conversion preserves assistant block types`() {
+        val raw = """{"type":"assistant/message","seq":349,"time":1,"data":{"turn":5,"step":1,"message":{"role":"assistant","content":[{"type":"reasoning","text":"thinking"},{"type":"text","text":"visible reply"}],"source":{"kind":"model","provider":"qwen-local","model":"qwen3.8-27b"},"id":"answer-1"},"usage":{"inputTokens":10,"outputTokens":2}}}"""
+        val event = decodeFromString<SessionEvent>(raw)
+
+        val envelope = sessionEventToEnvelope(event)
+        val assistant = EventFold("s1").fold(listOf(envelope)).nodes.single() as AssistantMessageNode
+
+        assertEquals(listOf("reasoning", "text"), assistant.blocks.map { it.kind })
+        assertEquals("visible reply", assistant.plainText)
+    }
+}

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/session/EventFold.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/session/EventFold.kt
@@ -129,7 +129,7 @@ private class FoldState(private val sessionId: String) {
                 val turn = data.jsonObject["turn"]?.jsonPrimitive?.intOrNull ?: 0
                 val step = data.jsonObject["step"]?.jsonPrimitive?.intOrNull ?: 0
                 val chunk = data.jsonObject["chunk"]?.jsonObject ?: return
-                mergeChunk(turn, step, chunk, event.seq)
+                mergeChunk(turn, step, chunk)
             }
 
             "assistant/message" -> {
@@ -209,8 +209,12 @@ private class FoldState(private val sessionId: String) {
 
     private fun key(turn: Int, step: Int) = "$turn.$step"
 
-    private fun mergeChunk(turn: Int, step: Int, chunk: JsonObject, seq: Long) {
+    private fun mergeChunk(turn: Int, step: Int, chunk: JsonObject) {
         val type = chunk["type"]?.jsonPrimitive?.contentOrNull ?: return
+        // Usage, finish, and future metadata chunks do not address a content block. Creating an
+        // accumulator for them would leave a phantom `unknown` block that can hide the complete
+        // content carried by a following non-streamed assistant/message event.
+        if (type !in BLOCK_CHUNK_TYPES) return
         val index = chunk["index"]?.jsonPrimitive?.intOrNull ?: 0
         val open = openByKey.getOrPut(key(turn, step)) { OpenAssistant(turn, step) }
         while (open.blocks.size <= index) open.blocks.add(MutableChatBlockAccumulator())
@@ -231,6 +235,16 @@ private class FoldState(private val sessionId: String) {
             "block-end" -> acc.raw = chunk["block"]
             else -> Unit
         }
+    }
+
+    private companion object {
+        val BLOCK_CHUNK_TYPES = setOf(
+            "block-start",
+            "text-delta",
+            "reasoning-delta",
+            "tool-call-delta",
+            "block-end",
+        )
     }
 
     private fun commit(open: OpenAssistant): List<ChatBlock> = open.blocks.map { acc ->

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/Events.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/Events.kt
@@ -1,4 +1,7 @@
-@file:OptIn(kotlinx.serialization.InternalSerializationApi::class)
+@file:OptIn(
+    kotlinx.serialization.ExperimentalSerializationApi::class,
+    kotlinx.serialization.InternalSerializationApi::class,
+)
 
 package com.labteto.dshmobile.core.wire.dto
 
@@ -7,6 +10,7 @@ import com.labteto.dshmobile.core.wire.encodeToJsonElement
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.SerialKind
@@ -90,11 +94,11 @@ object ContentBlockSerializer : KSerializer<ContentBlock> {
 
     override fun serialize(encoder: Encoder, value: ContentBlock) {
         val json: JsonElement = when (value) {
-            is ContentBlock.Text -> encodeToJsonElement(ContentBlock.Text.serializer(), value).withType("text")
-            is ContentBlock.Reasoning -> encodeToJsonElement(ContentBlock.Reasoning.serializer(), value).withType("reasoning")
-            is ContentBlock.Image -> encodeToJsonElement(ContentBlock.Image.serializer(), value).withType("image")
-            is ContentBlock.ToolCall -> encodeToJsonElement(ContentBlock.ToolCall.serializer(), value).withType("tool-call")
-            is ContentBlock.ToolResult -> encodeToJsonElement(ContentBlock.ToolResult.serializer(), value).withType("tool-result")
+            is ContentBlock.Text -> encodeWithType(ContentBlock.Text.serializer(), value)
+            is ContentBlock.Reasoning -> encodeWithType(ContentBlock.Reasoning.serializer(), value)
+            is ContentBlock.Image -> encodeWithType(ContentBlock.Image.serializer(), value)
+            is ContentBlock.ToolCall -> encodeWithType(ContentBlock.ToolCall.serializer(), value)
+            is ContentBlock.ToolResult -> encodeWithType(ContentBlock.ToolResult.serializer(), value)
             is UnknownContentBlock -> value.raw
         }
         (encoder as JsonEncoder).encodeJsonElement(json)
@@ -182,13 +186,13 @@ object StreamChunkSerializer : KSerializer<StreamChunk> {
 
     override fun serialize(encoder: Encoder, value: StreamChunk) {
         val json: JsonElement = when (value) {
-            is StreamChunk.BlockStart -> encodeToJsonElement(StreamChunk.BlockStart.serializer(), value).withType("block-start")
-            is StreamChunk.TextDelta -> encodeToJsonElement(StreamChunk.TextDelta.serializer(), value).withType("text-delta")
-            is StreamChunk.ReasoningDelta -> encodeToJsonElement(StreamChunk.ReasoningDelta.serializer(), value).withType("reasoning-delta")
-            is StreamChunk.ToolCallDelta -> encodeToJsonElement(StreamChunk.ToolCallDelta.serializer(), value).withType("tool-call-delta")
-            is StreamChunk.BlockEnd -> encodeToJsonElement(StreamChunk.BlockEnd.serializer(), value).withType("block-end")
-            is StreamChunk.Usage -> encodeToJsonElement(StreamChunk.Usage.serializer(), value).withType("usage")
-            is StreamChunk.Finish -> encodeToJsonElement(StreamChunk.Finish.serializer(), value).withType("finish")
+            is StreamChunk.BlockStart -> encodeWithType(StreamChunk.BlockStart.serializer(), value)
+            is StreamChunk.TextDelta -> encodeWithType(StreamChunk.TextDelta.serializer(), value)
+            is StreamChunk.ReasoningDelta -> encodeWithType(StreamChunk.ReasoningDelta.serializer(), value)
+            is StreamChunk.ToolCallDelta -> encodeWithType(StreamChunk.ToolCallDelta.serializer(), value)
+            is StreamChunk.BlockEnd -> encodeWithType(StreamChunk.BlockEnd.serializer(), value)
+            is StreamChunk.Usage -> encodeWithType(StreamChunk.Usage.serializer(), value)
+            is StreamChunk.Finish -> encodeWithType(StreamChunk.Finish.serializer(), value)
             is UnknownStreamChunk -> value.raw
         }
         (encoder as JsonEncoder).encodeJsonElement(json)
@@ -214,9 +218,13 @@ object StreamChunkSerializer : KSerializer<StreamChunk> {
  * Re-add it whenever a typed wire value is converted back to JSON; the transcript fold consumes
  * that JSON and otherwise sees every known block/chunk as an empty `unknown` value.
  */
+private fun <T> encodeWithType(serializer: SerializationStrategy<T>, value: T): JsonElement =
+    encodeToJsonElement(serializer, value).withType(serializer.descriptor.serialName)
+
 private fun JsonElement.withType(type: String): JsonElement = JsonObject(
-    linkedMapOf<String, JsonElement>("type" to JsonPrimitive(type)).apply {
+    linkedMapOf<String, JsonElement>().apply {
         putAll(this@withType.jsonObject)
+        put("type", JsonPrimitive(type))
     },
 )
 

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/Events.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/Events.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
@@ -89,11 +90,11 @@ object ContentBlockSerializer : KSerializer<ContentBlock> {
 
     override fun serialize(encoder: Encoder, value: ContentBlock) {
         val json: JsonElement = when (value) {
-            is ContentBlock.Text -> encodeToJsonElement(ContentBlock.Text.serializer(), value)
-            is ContentBlock.Reasoning -> encodeToJsonElement(ContentBlock.Reasoning.serializer(), value)
-            is ContentBlock.Image -> encodeToJsonElement(ContentBlock.Image.serializer(), value)
-            is ContentBlock.ToolCall -> encodeToJsonElement(ContentBlock.ToolCall.serializer(), value)
-            is ContentBlock.ToolResult -> encodeToJsonElement(ContentBlock.ToolResult.serializer(), value)
+            is ContentBlock.Text -> encodeToJsonElement(ContentBlock.Text.serializer(), value).withType("text")
+            is ContentBlock.Reasoning -> encodeToJsonElement(ContentBlock.Reasoning.serializer(), value).withType("reasoning")
+            is ContentBlock.Image -> encodeToJsonElement(ContentBlock.Image.serializer(), value).withType("image")
+            is ContentBlock.ToolCall -> encodeToJsonElement(ContentBlock.ToolCall.serializer(), value).withType("tool-call")
+            is ContentBlock.ToolResult -> encodeToJsonElement(ContentBlock.ToolResult.serializer(), value).withType("tool-result")
             is UnknownContentBlock -> value.raw
         }
         (encoder as JsonEncoder).encodeJsonElement(json)
@@ -181,13 +182,13 @@ object StreamChunkSerializer : KSerializer<StreamChunk> {
 
     override fun serialize(encoder: Encoder, value: StreamChunk) {
         val json: JsonElement = when (value) {
-            is StreamChunk.BlockStart -> encodeToJsonElement(StreamChunk.BlockStart.serializer(), value)
-            is StreamChunk.TextDelta -> encodeToJsonElement(StreamChunk.TextDelta.serializer(), value)
-            is StreamChunk.ReasoningDelta -> encodeToJsonElement(StreamChunk.ReasoningDelta.serializer(), value)
-            is StreamChunk.ToolCallDelta -> encodeToJsonElement(StreamChunk.ToolCallDelta.serializer(), value)
-            is StreamChunk.BlockEnd -> encodeToJsonElement(StreamChunk.BlockEnd.serializer(), value)
-            is StreamChunk.Usage -> encodeToJsonElement(StreamChunk.Usage.serializer(), value)
-            is StreamChunk.Finish -> encodeToJsonElement(StreamChunk.Finish.serializer(), value)
+            is StreamChunk.BlockStart -> encodeToJsonElement(StreamChunk.BlockStart.serializer(), value).withType("block-start")
+            is StreamChunk.TextDelta -> encodeToJsonElement(StreamChunk.TextDelta.serializer(), value).withType("text-delta")
+            is StreamChunk.ReasoningDelta -> encodeToJsonElement(StreamChunk.ReasoningDelta.serializer(), value).withType("reasoning-delta")
+            is StreamChunk.ToolCallDelta -> encodeToJsonElement(StreamChunk.ToolCallDelta.serializer(), value).withType("tool-call-delta")
+            is StreamChunk.BlockEnd -> encodeToJsonElement(StreamChunk.BlockEnd.serializer(), value).withType("block-end")
+            is StreamChunk.Usage -> encodeToJsonElement(StreamChunk.Usage.serializer(), value).withType("usage")
+            is StreamChunk.Finish -> encodeToJsonElement(StreamChunk.Finish.serializer(), value).withType("finish")
             is UnknownStreamChunk -> value.raw
         }
         (encoder as JsonEncoder).encodeJsonElement(json)
@@ -207,6 +208,17 @@ object StreamChunkSerializer : KSerializer<StreamChunk> {
         }
     }
 }
+
+/**
+ * The concrete serializers above do not emit the sealed class discriminator on their own.
+ * Re-add it whenever a typed wire value is converted back to JSON; the transcript fold consumes
+ * that JSON and otherwise sees every known block/chunk as an empty `unknown` value.
+ */
+private fun JsonElement.withType(type: String): JsonElement = JsonObject(
+    linkedMapOf<String, JsonElement>("type" to JsonPrimitive(type)).apply {
+        putAll(this@withType.jsonObject)
+    },
+)
 
 /** Serializable provider or transport failure facts; policy decides whether they are retryable. */
 @Serializable
@@ -1259,5 +1271,3 @@ object SessionEventSerializer : KSerializer<SessionEvent> {
         }
     }
 }
-
-

--- a/core/src/test/kotlin/com/labteto/dshmobile/core/session/EventFoldTest.kt
+++ b/core/src/test/kotlin/com/labteto/dshmobile/core/session/EventFoldTest.kt
@@ -206,6 +206,39 @@ class EventFoldTest {
     }
 
     @Test
+    fun metadataChunksDoNotHideANonStreamedAssistantMessage() {
+        val events = listOf(
+            event("assistant/chunk", 10, buildJsonObject {
+                put("turn", 1); put("step", 1)
+                putJsonObject("chunk") {
+                    put("type", "usage")
+                    putJsonObject("usage") { put("inputTokens", 10); put("outputTokens", 2) }
+                }
+            }),
+            event("assistant/chunk", 11, buildJsonObject {
+                put("turn", 1); put("step", 1)
+                putJsonObject("chunk") {
+                    put("type", "finish")
+                    putJsonObject("reason") { put("kind", "completed") }
+                }
+            }),
+            event("assistant/message", 12, buildJsonObject {
+                put("turn", 1); put("step", 1)
+                putJsonObject("message") {
+                    put("id", "answer-1")
+                    putJsonArray("content") {
+                        add(buildJsonObject { put("type", "text"); put("text", "visible reply") })
+                    }
+                }
+            }),
+        )
+
+        val assistant = EventFold("s1").fold(events).nodes.single() as AssistantMessageNode
+        assertEquals(listOf("text"), assistant.blocks.map { it.kind })
+        assertEquals("visible reply", assistant.plainText)
+    }
+
+    @Test
     fun roundTripsThroughWireJson() {
         // The wire JSON parser (lenient) must accept the event envelope.
         val raw = """{"type":"turn/end","seq":4,"time":5,"data":{"turn":1,"reason":{"kind":"completed"}},"extra":"ignored"}"""

--- a/core/src/test/kotlin/com/labteto/dshmobile/core/session/EventFoldTest.kt
+++ b/core/src/test/kotlin/com/labteto/dshmobile/core/session/EventFoldTest.kt
@@ -1,7 +1,13 @@
 package com.labteto.dshmobile.core.session
 
 import com.labteto.dshmobile.core.wire.WireJson
+import com.labteto.dshmobile.core.wire.decodeFromString
+import com.labteto.dshmobile.core.wire.encodeToJsonElement
+import com.labteto.dshmobile.core.wire.dto.SessionEvent
+import com.labteto.dshmobile.core.wire.dto.SessionEventSerializer
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
@@ -163,6 +169,40 @@ class EventFoldTest {
         )
         val user = EventFold("s1").fold(events).nodes.single() as UserMessageNode
         assertTrue(user.blocks.isEmpty())
+    }
+
+    /**
+     * The Android data layer decodes a typed event and then re-encodes its `data` for the fold.
+     * Concrete content-block serializers do not add their sealed-class discriminator themselves;
+     * losing it here turns both blocks into empty `unknown` rows and makes a completed reply vanish.
+     */
+    @Test
+    fun typedAssistantMessageKeepsBlockTypesWhenConvertedForTheFold() {
+        val raw = """{"type":"assistant/message","seq":349,"time":1,"data":{"turn":5,"step":1,"message":{"role":"assistant","content":[{"type":"reasoning","text":"thinking"},{"type":"text","text":"visible reply"}],"source":{"kind":"model","provider":"qwen-local","model":"qwen3.8-27b"},"id":"answer-1"},"usage":{"inputTokens":10,"outputTokens":2}}}"""
+        val typed = decodeFromString<SessionEvent>(raw)
+        val json = encodeToJsonElement(SessionEventSerializer, typed).jsonObject
+        val envelope = SessionEventEnvelope(
+            type = typed.type,
+            seq = typed.seq.toLong(),
+            time = typed.time,
+            data = json.getValue("data"),
+        )
+
+        val assistant = EventFold("s1").fold(listOf(envelope)).nodes.single() as AssistantMessageNode
+        assertEquals(listOf("reasoning", "text"), assistant.blocks.map { it.kind })
+        assertEquals("visible reply", assistant.plainText)
+    }
+
+    @Test
+    fun typedStreamChunkKeepsItsChunkAndCompletedBlockTypes() {
+        val raw = """{"type":"assistant/chunk","seq":12,"time":1,"data":{"turn":1,"step":1,"chunk":{"type":"block-end","index":0,"block":{"type":"text","text":"streamed reply"}}}}"""
+        val typed = decodeFromString<SessionEvent>(raw)
+        val json = encodeToJsonElement(SessionEventSerializer, typed).jsonObject
+        val data = json.getValue("data").jsonObject
+        val chunk = data.getValue("chunk").jsonObject
+
+        assertEquals("block-end", chunk.getValue("type").jsonPrimitive.content)
+        assertEquals("text", chunk.getValue("block").jsonObject.getValue("type").jsonPrimitive.content)
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Preserve the `type` discriminator when serializing known content blocks.
- Preserve the `type` discriminator for streamed assistant chunks and completed blocks.
- Add regression coverage for the typed event → JSON envelope → conversation fold path used by the Android data layer.

## Why

The Android client decodes `assistant/message` and `assistant/chunk` events into typed values, then re-encodes their `data` for the transcript fold. The concrete serializers did not emit their sealed-class discriminator, so valid `text` and `reasoning` blocks became empty `unknown` blocks. Completed model replies were stored by the harness but rendered as blank in DSH Mobile.

This was reproduced against a live harness history containing completed assistant replies. Before the fix, every reply folded to `unknown:null` blocks; after the fix, the same history produced visible assistant text.

## User impact

Assistant replies and streamed output remain renderable after the typed wire conversion, including after reconnecting and loading session history.

## Validation

- `./gradlew :core:test :app:testDebugUnitTest`
- `./gradlew :app:assembleDebug`
- Live history decode/fold check against the affected harness session