### PR TITLE
Preserve subagent entry kinds during serialization

### DIFF
--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SubagentDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SubagentDtos.kt
@@ -1,5 +1,4 @@
 @file:OptIn(
-    kotlinx.serialization.ExperimentalSerializationApi::class,
     kotlinx.serialization.InternalSerializationApi::class,
 )
 
@@ -10,10 +9,9 @@ import com.labteto.dshmobile.core.wire.encodeToJsonElement
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
-import kotlinx.serialization.descriptors.buildSerialDescriptor
 import kotlinx.serialization.descriptors.element
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -88,10 +86,10 @@ data class UnknownSubagentListEntry(
 /** Custom two-level (kind → mode) serializer for [SubagentListEntry]. */
 object SubagentListEntrySerializer : KSerializer<SubagentListEntry> {
     override val descriptor: SerialDescriptor = buildClassSerialDescriptor("SubagentListEntry") {
-        element("kind", buildSerialDescriptor("kotlin.String", PrimitiveKind.STRING))
-        element("id", buildSerialDescriptor("kotlin.String", PrimitiveKind.STRING), isOptional = true)
-        element("mode", buildSerialDescriptor("kotlin.String", PrimitiveKind.STRING), isOptional = true)
-        element("reason", buildSerialDescriptor("kotlin.String", PrimitiveKind.STRING), isOptional = true)
+        element("kind", String.serializer().descriptor)
+        element("id", String.serializer().descriptor, isOptional = true)
+        element("mode", String.serializer().descriptor, isOptional = true)
+        element("reason", String.serializer().descriptor, isOptional = true)
     }
 
     override fun serialize(encoder: Encoder, value: SubagentListEntry) {
@@ -125,7 +123,10 @@ object SubagentListEntrySerializer : KSerializer<SubagentListEntry> {
     }
 }
 
-/** Concrete serializers omit the computed [SubagentListEntry.kind]; restore it for the wire. */
+/**
+ * Concrete serializers omit the computed [SubagentListEntry.kind]; restore it for the wire.
+ * `mode` distinguishes child subtypes and survives because `WireJson` encodes defaults.
+ */
 private fun JsonElement.withKind(kind: String): JsonElement = JsonObject(
     linkedMapOf<String, JsonElement>().apply {
         putAll(this@withKind.jsonObject)

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SubagentDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SubagentDtos.kt
@@ -1,4 +1,7 @@
-@file:OptIn(kotlinx.serialization.InternalSerializationApi::class)
+@file:OptIn(
+    kotlinx.serialization.ExperimentalSerializationApi::class,
+    kotlinx.serialization.InternalSerializationApi::class,
+)
 
 package com.labteto.dshmobile.core.wire.dto
 
@@ -93,9 +96,12 @@ object SubagentListEntrySerializer : KSerializer<SubagentListEntry> {
 
     override fun serialize(encoder: Encoder, value: SubagentListEntry) {
         val json: JsonElement = when (value) {
-            is SubagentListEntry.ChildOneShot -> encodeToJsonElement(SubagentListEntry.ChildOneShot.serializer(), value)
-            is SubagentListEntry.ChildContinuable -> encodeToJsonElement(SubagentListEntry.ChildContinuable.serializer(), value)
-            is SubagentListEntry.Diagnostic -> encodeToJsonElement(SubagentListEntry.Diagnostic.serializer(), value)
+            is SubagentListEntry.ChildOneShot ->
+                encodeToJsonElement(SubagentListEntry.ChildOneShot.serializer(), value).withKind(value.kind)
+            is SubagentListEntry.ChildContinuable ->
+                encodeToJsonElement(SubagentListEntry.ChildContinuable.serializer(), value).withKind(value.kind)
+            is SubagentListEntry.Diagnostic ->
+                encodeToJsonElement(SubagentListEntry.Diagnostic.serializer(), value).withKind(value.kind)
             is UnknownSubagentListEntry -> value.raw
         }
         (encoder as JsonEncoder).encodeJsonElement(json)
@@ -118,6 +124,14 @@ object SubagentListEntrySerializer : KSerializer<SubagentListEntry> {
         }
     }
 }
+
+/** Concrete serializers omit the computed [SubagentListEntry.kind]; restore it for the wire. */
+private fun JsonElement.withKind(kind: String): JsonElement = JsonObject(
+    linkedMapOf<String, JsonElement>().apply {
+        putAll(this@withKind.jsonObject)
+        put("kind", JsonPrimitive(kind))
+    },
+)
 
 /** Complete direct-child catalog plus the delivery-time parent availability hint. */
 @Serializable
@@ -189,4 +203,3 @@ data class SubagentInterruptRequest(
 data class SubagentInterruptValue(
     @SerialName("accepted") val accepted: Boolean = true,
 )
-

--- a/core/src/test/kotlin/com/labteto/dshmobile/core/wire/dto/SubagentDtosTest.kt
+++ b/core/src/test/kotlin/com/labteto/dshmobile/core/wire/dto/SubagentDtosTest.kt
@@ -50,4 +50,33 @@ class SubagentDtosTest {
         assertEquals(UnknownSubagentListEntry("future-kind", raw), decoded)
         assertEquals(raw, encodeToJsonElement(SubagentListEntrySerializer, decoded))
     }
+
+    @Test
+    fun `catalog round trip preserves every known entry subtype`() {
+        val catalog = SubagentCatalog(
+            entries = listOf(
+                SubagentListEntry.ChildOneShot(
+                    id = "one-shot",
+                    activity = "idle",
+                    hasChildren = false,
+                    label = "Research",
+                ),
+                SubagentListEntry.ChildContinuable(
+                    id = "continuable",
+                    activity = "running",
+                    hasChildren = true,
+                    label = "Builder",
+                ),
+                SubagentListEntry.Diagnostic(
+                    id = "diagnostic",
+                    reason = "Transcript unavailable",
+                ),
+            ),
+            parentAvailable = true,
+        )
+
+        val encoded = encodeToJsonElement(SubagentCatalog.serializer(), catalog)
+
+        assertEquals(catalog, decodeFromJsonElement(SubagentCatalog.serializer(), encoded))
+    }
 }

--- a/core/src/test/kotlin/com/labteto/dshmobile/core/wire/dto/SubagentDtosTest.kt
+++ b/core/src/test/kotlin/com/labteto/dshmobile/core/wire/dto/SubagentDtosTest.kt
@@ -1,0 +1,53 @@
+package com.labteto.dshmobile.core.wire.dto
+
+import com.labteto.dshmobile.core.wire.decodeFromJsonElement
+import com.labteto.dshmobile.core.wire.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SubagentDtosTest {
+    @Test
+    fun `known list entries keep their kind through a JSON round trip`() {
+        val entries = listOf(
+            SubagentListEntry.ChildOneShot(
+                id = "one-shot",
+                activity = "idle",
+                hasChildren = false,
+                label = "Research",
+            ),
+            SubagentListEntry.ChildContinuable(
+                id = "continuable",
+                activity = "running",
+                hasChildren = true,
+                label = "Builder",
+            ),
+            SubagentListEntry.Diagnostic(
+                id = "diagnostic",
+                reason = "Transcript unavailable",
+            ),
+        )
+
+        entries.forEach { entry ->
+            val encoded = encodeToJsonElement(SubagentListEntrySerializer, entry)
+            assertEquals(entry.kind, encoded.jsonObject.getValue("kind").jsonPrimitive.content)
+            assertEquals(entry, decodeFromJsonElement(SubagentListEntrySerializer, encoded))
+        }
+    }
+
+    @Test
+    fun `unknown list entries remain lossless`() {
+        val raw = buildJsonObject {
+            put("kind", "future-kind")
+            put("id", "future-entry")
+            put("extra", true)
+        }
+        val decoded = decodeFromJsonElement(SubagentListEntrySerializer, raw)
+
+        assertEquals(UnknownSubagentListEntry("future-kind", raw), decoded)
+        assertEquals(raw, encodeToJsonElement(SubagentListEntrySerializer, decoded))
+    }
+}


### PR DESCRIPTION
## What changed

- Restore the computed kind discriminator when known subagent list entries are serialized.
- Preserve unknown subagent entries losslessly.
- Add round-trip coverage for one-shot, continuable, diagnostic, and unknown entries.

## Why

ChildOneShot, ChildContinuable, and Diagnostic expose kind as a computed property, so their concrete serializers omit it. Re-encoding and decoding one of those entries therefore produced UnknownSubagentListEntry. The current application does not trigger that round trip, but future persistence, replay, or forwarding would make the latent bug user-visible.

## Impact

No current UI behavior changes. Known subagent entries now retain their correct subtype across JSON round trips.

## Validation

- ./gradlew test
- ./gradlew lintDebug
- 346 tests, 0 failures