### PR TITLE
Fix intermittent send taps and keyboard gap

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
             android:configChanges="locale|layoutDirection"
             android:exported="true"
             android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.DshMobile.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/labteto/dshmobile/ui/screens/main/ChatScreen.kt
+++ b/app/src/main/java/com/labteto/dshmobile/ui/screens/main/ChatScreen.kt
@@ -168,15 +168,13 @@ fun ChatScreen(
         }
     }
 
-    fun send() {
-        val text = draft
+    fun send(text: String) {
         val pending = attachments.toList()
         if (text.isBlank() && pending.isEmpty()) return
         // A slash line that names a registered command is not a message: `session.prompt` would
         // hand it to the model verbatim, so it has to be recognised here and written through the
         // command gateway. A miss falls through to the prompt path — that is how skills work.
         val submission = adjudicate(text, commands, pending.isNotEmpty())
-        draft = ""
         attachments.clear()
         if (submission is Submission.Command) {
             scope.launch { report(store.runCommand(submission.line)) }

--- a/app/src/main/java/com/labteto/dshmobile/ui/screens/main/Composer.kt
+++ b/app/src/main/java/com/labteto/dshmobile/ui/screens/main/Composer.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -96,13 +97,16 @@ internal fun Composer(
     running: Boolean,
     enabled: Boolean,
     onOpenSheet: () -> Unit,
-    onSend: () -> Unit,
+    onSend: (String) -> Unit,
     onStop: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val colors = DsTheme.colors
     val haptics = LocalHapticFeedback.current
     val canSend = enabled && (draft.isNotBlank() || attachments.isNotEmpty())
+    val currentDraft by rememberUpdatedState(draft)
+    val currentOnDraftChange by rememberUpdatedState(onDraftChange)
+    val currentOnSend by rememberUpdatedState(onSend)
 
     Surface(
         modifier = modifier
@@ -214,8 +218,10 @@ internal fun Composer(
                             tint = if (canSend) Color.White else colors.labelTertiary,
                             enabled = canSend,
                             onClick = {
+                                val text = currentDraft
+                                currentOnDraftChange("")
                                 haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                                onSend()
+                                currentOnSend(text)
                             },
                         )
                     }


### PR DESCRIPTION
## Summary

- pass the latest composer text directly through the Send callback
- clear the visible draft before dispatch while retaining the captured text
- force the activity to resize above the software keyboard instead of panning the entire window

## Root cause

The animated Send control could retain a callback that closed over an older, empty `draft` value. A tap visibly registered, but `ChatScreen.send()` then saw a blank message and returned without dispatching it.

The activity also left soft-input adjustment unspecified. On a Samsung device Android selected `adjustPan`, shifting the app upward and leaving a large empty region between the composer and Gboard.

## Impact

Send now dispatches the exact current text even when recomposition and the button animation overlap. Opening the keyboard keeps the composer directly above it without the large gap.

## Validation

- `./gradlew :app:testDebugUnitTest :app:assembleDebug`
- installed the debug APK on a Samsung SM-S928U1 and successfully sent a prompt to a live harness
- confirmed the activity reports `adjust=resize` and the composer meets the top of Gboard with no empty gap
