### PR TITLE
Move the protocol baseline to harness 0.1.0-rc.8

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,7 +32,7 @@ body:
     attributes:
       label: Harness version
       description: Shown on the connect screen and in Settings → Harness (`host.describe`).
-      placeholder: e.g. 0.1.0-rc.5
+      placeholder: e.g. 0.1.0-rc.8
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,6 +2,9 @@
 # forms do not fit still need somewhere to go, and Discussions are not enabled.
 blank_issues_enabled: true
 contact_links:
+  - name: Project website
+    url: https://dshm.zyphite.com
+    about: What the app is, what it looks like and how to get it running, on one page.
   - name: Cannot connect to the harness
     url: https://github.com/sorsama/deepseek-harness-mobile/wiki/Troubleshooting
     about: Every failure the app names, with its cause and its fix. Almost always the computer's firewall, a harness still bound to loopback, or a different subnet.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Conventions live in CONTRIBUTING.md; the deeper documents are in docs/.
 
 <!--
 Say what you actually ran, not what should work. For example:
-- Real harness 0.1.0-rc.7 over adb reverse, Pixel 6a / Android 14
+- Real harness 0.1.0-rc.8 over adb reverse, Pixel 6a / Android 14
 - Real harness over Wi-Fi LAN mode
 - mock-harness only
 - Unit tests only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,83 @@
 All notable changes to DSH Mobile are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/); the project uses SemVer.
 
+## [0.5.0] - 2026-08-20
+
+The baseline moves to harness **0.1.0-rc.8**, and this one is a migration rather
+than a re-verification. The previous move, rc.5 → rc.7, touched nothing on the
+wire at all; this one changes a call's arguments, adds a required field to two
+shapes, and gives slash commands something they never had — the ability to carry
+a picture.
+
+### Fixed
+
+- **Every slash command was about to stop working.** rc.8 gave
+  `commands/execute` a third argument, `images`, and the harness's gateway
+  matches an args object against the method it is calling *exactly* — it refuses
+  a missing key as readily as an unexpected one. This client sent two arguments,
+  so against an rc.8 harness `/compact`, `/plan`, the permission picker and the
+  feedback buttons would each have failed, and — because an unrecognised error
+  code is treated as a broken link — each failure would also have raised the red
+  connection banner over a session that was perfectly healthy. The client now
+  sends the shape the host in front of it actually declares. It works out which
+  by looking for `host.describe.home`, a field rc.8 made required and rc.7 never
+  sent, rather than by comparing version strings: the app has never been willing
+  to branch on a version string, and a fork or a downstream build deserves to be
+  judged on what it sends. Both releases keep working.
+- **A stopped answer used to vanish.** Tapping stop mid-reply discarded every
+  word the model had already written: nothing was ever committed for a cancelled
+  step, so the transcript closed over the gap as if the turn had never spoken.
+  rc.8 finalises that prefix as a real message and marks it, and the client now
+  reads the mark. It also stops the last complete message of a multi-step turn
+  from being labelled interrupted when it was the *next* step that got cut.
+- **Attaching several images made several messages.** The prompt call takes a
+  list of content parts and the harness admits that list as one batch — this
+  client was sending one call per picture, so four images became four separate
+  user messages, and the host's own per-message limits on image count and total
+  size could never fire at all. One message is now one call.
+- `web_search` rows in the transcript went blank. rc.8 replaced the tool's single
+  `query` with a `queries` array of up to four, and a row reading only the old key
+  found nothing left to show; it now reads either, and lists them.
+
+### Added
+
+- **`/goal` and `/plan` take image attachments.** Type the command with pictures
+  attached and they ride along — into the goal's objective, or into the message
+  that opens plan mode.
+- **A command that cannot take your pictures now says so.** Before, attaching an
+  image to `/compact` silently demoted the whole line to a prompt: the literal
+  text `/compact` went to the model, the command never ran, and nothing on screen
+  explained why. It is refused instead, with the draft and the images both left
+  where they were so the refusal is something you can act on.
+- **Images are checked against every bound the host publishes, before upload.**
+  The count, the total size, the file size, the resolution and — new in rc.8 —
+  the 2000px per-side limit. Three of those five were being received and ignored,
+  and the per-side one did not exist. A refused picture now names the limit it
+  crossed rather than reading "Could not attach that image", and so does a
+  refusal that still comes back from the harness: the same sentences serve both,
+  so it does not matter to you which side said no.
+- The picker also catches a file whose contents contradict its extension — a JPEG
+  named `.png` — which the harness would have rejected after the round trip.
+
+### Changed
+
+- Protocol baseline moves to harness **0.1.0-rc.8**. What moved on the wire:
+  `host.describe` gained a required `home`; the `imageLimits` projection gained a
+  required `maxImageDimension`; `commands/execute` gained a required `images`
+  argument; command descriptors gained an optional `input.images`;
+  `assistant/message` gained an optional `interrupted`; `web_search` swapped
+  `query` for `queries`. Four `team/*` event types were added for an experimental
+  feature no shipped harness composes, and they pass through as unknown events
+  the way anything unfamiliar does.
+- The shipped per-image limit is **3.5MB**, down from 5MB, following the harness's
+  own default. It applies only when a harness publishes no limits of its own; one
+  that does is still obeyed. On an older harness that publishes none, a 4MB image
+  it would have accepted is now turned away — the reverse mistake costs a round
+  trip and a failed turn, so this is the direction to be wrong in.
+- The mock harness answers a mismatched argument object the way the real gateway
+  does, instead of accepting whatever arrives. That is what would have caught the
+  `commands/execute` break from this side, and now it does.
+
 ## [0.4.0] - 2026-08-18
 
 Two threads run through this release. The first is the question the agent asks

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 </p>
 
 <p align="center">
+  <a href="https://dshm.zyphite.com"><img alt="Website" src="https://img.shields.io/badge/website-dshm.zyphite.com-4176E6?style=flat-square"></a>
   <a href="https://github.com/sorsama/deepseek-harness-mobile/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/sorsama/deepseek-harness-mobile?style=flat-square"></a>
   <a href="https://github.com/sorsama/deepseek-harness-mobile/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/sorsama/deepseek-harness-mobile/ci.yml?branch=main&style=flat-square"></a>
   <img alt="Android 8.0+" src="https://img.shields.io/badge/Android-8.0%2B-3DDC84?style=flat-square">
@@ -20,6 +21,9 @@
 DSH Mobile is an **unofficial companion app** for the
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (MIT), mirroring its web GUI
 feature-for-feature in the harness's own visual language. Android only, Kotlin + Jetpack Compose.
+
+**[dshm.zyphite.com](https://dshm.zyphite.com)** is the project site — what the app is, what it
+looks like, and how to get it running, on one page.
 
 The [**wiki**](https://github.com/sorsama/deepseek-harness-mobile/wiki) is the user-facing guide:
 [getting started](https://github.com/sorsama/deepseek-harness-mobile/wiki/Getting-Started),
@@ -71,7 +75,7 @@ a [feature tour](https://github.com/sorsama/deepseek-harness-mobile/wiki/Feature
 
 - Android 8.0+ (minSdk 26).
 - A running [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-  (tested against `0.1.0-rc.7`).
+  (tested against `0.1.0-rc.8`).
 
 ## Quick start
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
  * upgrade at all. The code is derived from the name so it rises with semver on its own; the
  * fallback is what a local `assembleRelease` builds.
  */
-val dshVersionName: String = System.getenv("DSH_VERSION_NAME")?.takeIf { it.isNotBlank() } ?: "0.4.0"
+val dshVersionName: String = System.getenv("DSH_VERSION_NAME")?.takeIf { it.isNotBlank() } ?: "0.5.0"
 
 val dshVersionCode: Int = dshVersionName
     .substringBefore('-')

--- a/app/src/main/java/com/labteto/dshmobile/data/SessionStore.kt
+++ b/app/src/main/java/com/labteto/dshmobile/data/SessionStore.kt
@@ -22,6 +22,9 @@ import com.labteto.dshmobile.core.wire.dto.AskUserQuestionIntent
 import com.labteto.dshmobile.core.wire.dto.AskUserQuestionItem
 import com.labteto.dshmobile.core.wire.dto.CUSTOM_PRESET
 import com.labteto.dshmobile.core.wire.dto.CommandDescriptor
+import com.labteto.dshmobile.core.wire.dto.EncodedImageAttachment
+import com.labteto.dshmobile.core.wire.dto.ImageRejection
+import com.labteto.dshmobile.core.wire.dto.imageRejectionOf
 import com.labteto.dshmobile.core.wire.dto.ContentBlock
 import com.labteto.dshmobile.core.wire.dto.ContextBreakdownView
 import com.labteto.dshmobile.core.wire.dto.ContextPressureView
@@ -144,6 +147,22 @@ sealed interface CommandOutcome {
 
     /** The command ran and reported a usage or state failure. */
     data class Failed(val message: String) : CommandOutcome
+}
+
+/** What the harness did with a prompt. */
+sealed interface PromptOutcome {
+    /** Accepted; the turn is the transcript's business now. */
+    data object Ok : PromptOutcome
+
+    /**
+     * The host refused the images. Carried as its own case because it is a composer problem, not
+     * a connection problem: raising the persistent connection banner for an image that is 200px
+     * too wide tells the user their harness is broken when only their picture is.
+     */
+    data class Rejected(val rejection: ImageRejection, val reason: String?) : PromptOutcome
+
+    /** Anything else; the connection banner already carries [message]. */
+    data class Failed(val message: String) : PromptOutcome
 }
 
 /** What the harness did with an answer to a question request, or with a dismissal of one. */
@@ -1092,23 +1111,28 @@ class SessionStore @Inject constructor(
     suspend fun prompt(text: String, mode: String) =
         promptContent(mode, listOf(PromptContentPart.Text(text)))
 
-    /** Prompt with an attached raster image (bytes submitted base64, as the browser wire does). */
-    suspend fun promptWithImage(
+    /**
+     * Prompt with attached raster images (bytes submitted base64, as the browser wire does).
+     *
+     * All of them ride *one* call. `session.prompt` takes a list of content parts and the host
+     * admits that list as a single batch, which is where its per-message image count and
+     * aggregate-size limits live — sending one image per call, as this client used to, split one
+     * message into several and meant those two limits could never fire at all.
+     */
+    suspend fun promptWithImages(
         text: String,
         mode: String,
-        mediaType: String,
-        base64Data: String,
-        name: String? = null,
-    ) {
+        images: List<EncodedImageAttachment>,
+    ): PromptOutcome {
         val parts = mutableListOf<PromptContentPart>()
         if (text.isNotBlank()) parts.add(PromptContentPart.Text(text))
-        parts.add(PromptContentPart.Image(mediaType, base64Data, name))
-        promptContent(mode, parts)
+        images.mapTo(parts) { PromptContentPart.Image(it.mediaType, it.data, it.name) }
+        return promptContent(mode, parts)
     }
 
-    private suspend fun promptContent(mode: String, content: List<PromptContentPart>) {
-        val sid = currentSessionId.value ?: return
-        val api = apiOrNull() ?: return
+    private suspend fun promptContent(mode: String, content: List<PromptContentPart>): PromptOutcome {
+        val sid = currentSessionId.value ?: return PromptOutcome.Failed("no open session")
+        val api = apiOrNull() ?: return PromptOutcome.Failed("not connected")
         val safeMode = if (mode == "steer") "steer" else "queue"
         val zone = TimeZone.getDefault().id
         val request = SessionPromptRequest(
@@ -1117,9 +1141,18 @@ class SessionStore @Inject constructor(
             content = content,
             clientTimeZone = zone,
         )
-        when (val r = api.sessionPrompt(request)) {
-            is RpcResult.Ok -> Unit
-            is RpcResult.Err -> setConnectionError(r.error.message)
+        return when (val r = api.sessionPrompt(request)) {
+            is RpcResult.Ok -> PromptOutcome.Ok
+            is RpcResult.Err -> if (r.error.code == "attachment-error") {
+                // The host declined the pictures, not the connection. Report it where the pictures
+                // are so the composer can keep them and say which bound they crossed.
+                val reason = (r.error.details as? JsonObject)
+                    ?.get("reason")?.jsonPrimitive?.contentOrNull
+                PromptOutcome.Rejected(imageRejectionOf(reason.orEmpty()), reason)
+            } else {
+                setConnectionError(r.error.message)
+                PromptOutcome.Failed(r.error.message)
+            }
         }
     }
 
@@ -1433,7 +1466,7 @@ class SessionStore @Inject constructor(
     }
 
     /**
-     * Run one complete slash-command line.
+     * Run one complete slash-command line, optionally carrying the composer's images.
      *
      * The typert remote is the *only* command write path: `session.prompt` does not inspect its
      * content, so a leading-slash prompt reaches the model as ordinary user text (this store used
@@ -1443,11 +1476,19 @@ class SessionStore @Inject constructor(
      * The remote answers `undefined` when the line parses to no registered command, and the wire
      * codec folds an absent `value` slot into an empty object — so the discriminator is the
      * presence of `commandId`, not the emptiness of the value.
+     *
+     * [images] must be empty unless the command's descriptor declares it takes them and the host
+     * carries them at all — see `DshApiClient.acceptsCommandImages`. A host that admits them but
+     * whose handler will not use them (`/plan off`, `/goal pause`) answers with an ordinary error
+     * result, which is the harness's own division of labour and not worth mirroring here.
      */
-    suspend fun runCommand(line: String): CommandOutcome {
+    suspend fun runCommand(
+        line: String,
+        images: List<EncodedImageAttachment> = emptyList(),
+    ): CommandOutcome {
         val sid = currentSessionId.value ?: return CommandOutcome.Failed("no open session")
         val api = apiOrNull() ?: return CommandOutcome.Failed("not connected")
-        return when (val r = api.commandsExecute(sid, line)) {
+        return when (val r = api.commandsExecute(sid, line, images)) {
             is RpcResult.Ok -> {
                 val execution = r.value as? JsonObject
                 val commandId = execution?.get("commandId")
@@ -1464,6 +1505,9 @@ class SessionStore @Inject constructor(
                 }
             }
             is RpcResult.Err -> when (r.error.code) {
+                // The images were refused, by the host or by the client's own guard. A composer
+                // problem, so it must not raise the connection banner.
+                "attachment-error" -> CommandOutcome.Failed(r.error.message)
                 // No command gateway in this build (404) or the trust fence refused it (403).
                 // Neither is a connection fault, so the menu retires rather than the session.
                 "capability-unavailable", "forbidden" -> {
@@ -1630,6 +1674,14 @@ class SessionStore @Inject constructor(
         is SubagentListEntry.Diagnostic -> entry.id
         is UnknownSubagentListEntry -> null
     }
+
+    /**
+     * Whether this connection's harness carries images on a slash command (harness 0.1.0-rc.8).
+     *
+     * Read at submit time rather than observed: the value is latched during the handshake, long
+     * before any command can be dispatched, and it never changes within a connection.
+     */
+    val commandImagesSupported: Boolean get() = connectionManager.connectedApi?.acceptsCommandImages == true
 
     private fun apiOrNull(): DshApiClient? {
         val api = connectionManager.connectedApi

--- a/app/src/main/java/com/labteto/dshmobile/ui/screens/main/ChatNodeItem.kt
+++ b/app/src/main/java/com/labteto/dshmobile/ui/screens/main/ChatNodeItem.kt
@@ -210,7 +210,10 @@ internal val STRUCTURAL_EVENT_TYPES = setOf(
 private fun AssistantMessage(node: AssistantMessageNode, context: ChatNodeContext) {
     val colors = DsTheme.colors
     val isLast = context.nodes.lastOrNull()?.seq == node.seq
-    val streaming = context.running && isLast
+    // A message the harness marked as a cancelled turn's prefix arrives before that turn's end,
+    // so `running` is still true for a frame. Without this the last thing the user sees after
+    // tapping stop is the answer apparently still being written.
+    val streaming = context.running && isLast && !node.interrupted
     val reasoningExpanded = remember(node.seq) { mutableStateMapOf<Int, Boolean>() }
     var actionsVisible by remember(node.seq) { mutableStateOf(false) }
 

--- a/app/src/main/java/com/labteto/dshmobile/ui/screens/main/ChatScreen.kt
+++ b/app/src/main/java/com/labteto/dshmobile/ui/screens/main/ChatScreen.kt
@@ -36,6 +36,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.labteto.dshmobile.core.wire.dto.AskUserQuestionAnswer
 import com.labteto.dshmobile.core.wire.dto.AskUserQuestionAnswerItem
 import com.labteto.dshmobile.core.wire.dto.AskUserQuestionOption
+import com.labteto.dshmobile.core.wire.dto.ImageLimitsView
+import com.labteto.dshmobile.data.CommandOutcome
+import com.labteto.dshmobile.data.PromptOutcome
 import com.labteto.dshmobile.data.QuestionOutcome
 import com.labteto.dshmobile.data.SessionStore
 import com.labteto.dshmobile.ui.components.ApprovalPanel
@@ -115,14 +118,11 @@ fun ChatScreen(
     val commandFailed = stringResource(R.string.err_command_failed)
     val unknownCommand = stringResource(R.string.err_command_unknown)
 
-    fun report(outcome: com.labteto.dshmobile.data.CommandOutcome) {
+    fun report(outcome: CommandOutcome) {
         when (outcome) {
-            is com.labteto.dshmobile.data.CommandOutcome.Ok ->
-                outcome.text?.takeIf { it.isNotBlank() }?.let { toast.second(it) }
-            is com.labteto.dshmobile.data.CommandOutcome.Unknown ->
-                toast.second(unknownCommand.format(outcome.line))
-            is com.labteto.dshmobile.data.CommandOutcome.Failed ->
-                toast.second(commandFailed.format(outcome.message))
+            is CommandOutcome.Ok -> outcome.text?.takeIf { it.isNotBlank() }?.let { toast.second(it) }
+            is CommandOutcome.Unknown -> toast.second(unknownCommand.format(outcome.line))
+            is CommandOutcome.Failed -> toast.second(commandFailed.format(outcome.message))
         }
     }
 
@@ -148,21 +148,39 @@ fun ChatScreen(
             val resolver = context.contentResolver
             val mediaType = resolver.getType(uri)
             val bytes = runCatching { resolver.openInputStream(uri)?.use { it.readBytes() } }.getOrNull()
-            val limits = imageLimits
-            // The host publishes its own attachment bounds; checking them here means a rejection
-            // surfaces before the round trip rather than as a failed turn.
-            if (bytes == null || bytes.isEmpty() || mediaType == null ||
-                (limits != null && !limits.accepts(mediaType, bytes.size)) ||
-                (limits == null && bytes.size > 5_242_880)
-            ) {
+            if (bytes == null || bytes.isEmpty() || mediaType == null) {
+                // Nothing came back from the provider at all — a read failure, not a refusal.
                 toast.second(context.getString(R.string.err_attachment_failed))
+                return@launch
+            }
+            // The host publishes its own attachment bounds, and its defaults stand in until the
+            // projection arrives. Checking them here means a refusal lands while the picture is
+            // still in hand, and names the same limit the host would have named.
+            val limits = imageLimits ?: ImageLimitsView()
+            val pick = decodePick(bytes)
+            val rejection = limits.admitBatch(
+                pendingCount = attachments.size,
+                pendingBytes = attachments.sumOf { it.bytes.toLong() },
+                addedBytes = bytes.size,
+            ) ?: limits.admitImage(
+                declaredMediaType = mediaType,
+                detectedMediaType = pick.detectedMediaType,
+                bytes = bytes.size,
+                width = pick.width,
+                height = pick.height,
+            )
+            if (rejection != null) {
+                toast.second(imageRejectionText(context, rejection, limits))
                 return@launch
             }
             attachments.add(
                 PendingAttachment(
                     mediaType = mediaType,
                     base64 = Base64.encodeToString(bytes, Base64.NO_WRAP),
-                    preview = decodePreview(bytes),
+                    preview = pick.preview,
+                    bytes = bytes.size,
+                    width = pick.width,
+                    height = pick.height,
                 ),
             )
         }
@@ -174,26 +192,57 @@ fun ChatScreen(
         // A slash line that names a registered command is not a message: `session.prompt` would
         // hand it to the model verbatim, so it has to be recognised here and written through the
         // command gateway. A miss falls through to the prompt path — that is how skills work.
-        val submission = adjudicate(text, commands, pending.isNotEmpty())
-        attachments.clear()
-        if (submission is Submission.Command) {
-            scope.launch { report(store.runCommand(submission.line)) }
-            return
-        }
-        scope.launch {
-            if (pending.isEmpty()) {
-                store.prompt(text, mode)
-            } else {
-                // The prompt API takes one image per call; the text rides the first so the message
-                // stays a single turn rather than fragmenting across attachments.
-                pending.forEachIndexed { index, attachment ->
-                    store.promptWithImage(
-                        text = if (index == 0) text else "",
-                        mode = mode,
-                        mediaType = attachment.mediaType,
-                        base64Data = attachment.base64,
-                        name = attachment.name,
-                    )
+        when (val submission = adjudicate(text, commands, pending.size, store.commandImagesSupported)) {
+            is Submission.Refused -> {
+                // Nothing is sent and nothing is dropped. The composer clears the draft on its way
+                // here, so put it back, and leave the images alone — a refusal the user cannot act
+                // on without re-picking every attachment is not much of a refusal.
+                draft = text
+                val message = when (submission.reason) {
+                    RefusalReason.COMMAND_TAKES_NO_IMAGES -> R.string.err_command_no_images
+                    RefusalReason.HOST_TOO_OLD -> R.string.err_command_images_host
+                }
+                toast.second(context.getString(message, submission.command))
+            }
+
+            is Submission.Command -> {
+                attachments.clear()
+                val images = pending.map { it.encoded() }
+                scope.launch {
+                    val outcome = store.runCommand(submission.line, images)
+                    // An image-carrying command consumes its images only on success, as the
+                    // harness client does: an error result is something to correct, and correcting
+                    // it should not start with picking every picture again. A plain command that
+                    // fails keeps today's behaviour, because its whole submission was the line.
+                    // The restore only lands in a composer nobody has touched meanwhile — the call
+                    // is in flight while the user can still type and pick.
+                    if (images.isNotEmpty() && outcome is CommandOutcome.Failed) {
+                        if (draft.isBlank()) draft = text
+                        if (attachments.isEmpty()) attachments.addAll(pending)
+                    }
+                    report(outcome)
+                }
+            }
+
+            is Submission.Prompt -> {
+                attachments.clear()
+                scope.launch {
+                    // One call, whatever the count. The host admits a prompt's images as a single
+                    // batch, and that batch is the only thing its per-message count and total-size
+                    // bounds are measured against — sending one image per call made a single
+                    // message into several and put both limits permanently out of reach.
+                    val outcome = if (pending.isEmpty()) {
+                        store.prompt(text, mode)
+                    } else {
+                        store.promptWithImages(text, mode, pending.map { it.encoded() })
+                    }
+                    if (outcome is PromptOutcome.Rejected) {
+                        if (draft.isBlank()) draft = text
+                        if (attachments.isEmpty()) attachments.addAll(pending)
+                        toast.second(
+                            imageRejectionText(context, outcome.rejection, imageLimits, outcome.reason),
+                        )
+                    }
                 }
             }
         }
@@ -386,7 +435,17 @@ fun ChatScreen(
             canAttach = currentSessionId != null,
             onModeChange = { mode = it },
             onAttach = { imagePicker.launch("image/*") },
-            onRunCommand = { line -> scope.launch { report(store.runCommand(line)) } },
+            // The sheet only auto-runs commands that take no input at all, and a command that
+            // takes no input takes no images either — so a pending attachment refuses here for
+            // the same reason it refuses at the composer, rather than being silently dropped.
+            onRunCommand = { line ->
+                val name = line.removePrefix("/").substringBefore(' ')
+                if (attachments.isEmpty()) {
+                    scope.launch { report(store.runCommand(line)) }
+                } else {
+                    toast.second(context.getString(R.string.err_command_no_images, name))
+                }
+            },
             onPrefillDraft = { prefix -> draft = prefix },
             onDismiss = { sheet = null },
         )
@@ -414,19 +473,42 @@ private enum class ChatSheet { Commands, Models, Presets, Subagents }
 
 
 /**
- * A thumbnail for the composer strip, decoded straight off the picked bytes.
+ * What a bounds pass over the picked bytes tells us: the image's intrinsic size, the media type
+ * its bytes actually are, and a thumbnail for the composer strip.
  *
- * This one *does* need a bounds pass: the picker hands over raw bytes with no intrinsic size
- * attached, unlike an attachment reference that already carries its dimensions.
+ * A [width] of zero means the bytes did not parse as an image at all.
  */
-private fun decodePreview(bytes: ByteArray): ImageBitmap? = runCatching {
+private data class DecodedPick(
+    val width: Int,
+    val height: Int,
+    val detectedMediaType: String?,
+    val preview: ImageBitmap?,
+)
+
+/**
+ * Measure and thumbnail a picked image in one pass.
+ *
+ * The bounds pass was always here for the thumbnail's sample size; it also answers the two
+ * questions the host's admission asks — how large is this, and is it really the type its provider
+ * claims — so the picker can refuse an image before spending a round trip on it rather than after.
+ */
+private fun decodePick(bytes: ByteArray): DecodedPick {
     val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-    BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
-    val options = BitmapFactory.Options().apply {
-        inSampleSize = sampleSizeFor(bounds.outWidth, PREVIEW_WIDTH_PX)
+    runCatching { BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds) }
+    val width = bounds.outWidth.coerceAtLeast(0)
+    val height = bounds.outHeight.coerceAtLeast(0)
+    val preview = if (width <= 0) {
+        null
+    } else {
+        runCatching {
+            val options = BitmapFactory.Options().apply {
+                inSampleSize = sampleSizeFor(width, PREVIEW_WIDTH_PX)
+            }
+            BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)?.asImageBitmap()
+        }.getOrNull()
     }
-    BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)?.asImageBitmap()
-}.getOrNull()
+    return DecodedPick(width, height, bounds.outMimeType, preview)
+}
 
 /** The composer thumbnail is 56dp; decoding much past that is wasted memory. */
 private const val PREVIEW_WIDTH_PX = 224

--- a/app/src/main/java/com/labteto/dshmobile/ui/screens/main/Composer.kt
+++ b/app/src/main/java/com/labteto/dshmobile/ui/screens/main/Composer.kt
@@ -57,6 +57,7 @@ import com.labteto.dshmobile.R
 import com.labteto.dshmobile.core.wire.dto.ContextBreakdownView
 import com.labteto.dshmobile.core.wire.dto.ContextPressureView
 import com.labteto.dshmobile.core.wire.dto.FULL_ACCESS_PRESET
+import com.labteto.dshmobile.core.wire.dto.EncodedImageAttachment
 import com.labteto.dshmobile.core.wire.dto.PermissionSelect
 import com.labteto.dshmobile.core.wire.dto.displayPermissionPreset
 import com.labteto.dshmobile.ui.components.ContextMeter
@@ -67,13 +68,25 @@ import com.labteto.dshmobile.ui.theme.DsSpacing
 import com.labteto.dshmobile.ui.theme.DsTheme
 import com.labteto.dshmobile.ui.theme.DsType
 
-/** A picked image waiting to be sent, held with its decoded preview. */
+/**
+ * A picked image waiting to be sent, held with its decoded preview.
+ *
+ * [bytes], [width] and [height] are the encoded size and intrinsic dimensions the picker already
+ * had to learn to admit the image; keeping them means the *next* pick can be measured against the
+ * message's running totals without decoding everything already attached a second time.
+ */
 internal data class PendingAttachment(
     val mediaType: String,
     val base64: String,
     val preview: ImageBitmap?,
+    val bytes: Int,
+    val width: Int,
+    val height: Int,
     val name: String? = null,
-)
+) {
+    /** The wire form `session.prompt` and `commands/execute` both carry. */
+    fun encoded(): EncodedImageAttachment = EncodedImageAttachment(mediaType, base64, name)
+}
 
 /**
  * The message composer, laid out like the harness's own: the `+` and the permission chip on the

--- a/app/src/main/java/com/labteto/dshmobile/ui/screens/main/ImageErrorCopy.kt
+++ b/app/src/main/java/com/labteto/dshmobile/ui/screens/main/ImageErrorCopy.kt
@@ -1,0 +1,65 @@
+package com.labteto.dshmobile.ui.screens.main
+
+import android.content.Context
+import com.labteto.dshmobile.R
+import com.labteto.dshmobile.core.wire.dto.ImageLimitsView
+import com.labteto.dshmobile.core.wire.dto.ImageRejection
+import java.util.Locale
+
+/**
+ * What to tell the user when an image will not go.
+ *
+ * The port of the harness's own `attachmentErrorText` (`packages/client/ui-conversation/src/
+ * client/image-labels.ts`). One table serves both sides of the refusal — the check this client
+ * runs before uploading and the `attachment-error` a host still answers with — so a rejection
+ * reads the same either way, and a limit the client has not learned about yet still names itself.
+ */
+
+/**
+ * Byte count as user-facing megabytes (`10MB`, `2.5MB`) — the harness's `imageSizeText`.
+ *
+ * The decimal separator is fixed rather than localised: this is a limit marker the user may well
+ * be comparing against what the harness itself wrote, and the two have to look like one number.
+ */
+internal fun imageSizeText(bytes: Long): String {
+    val mb = bytes.toDouble() / (1024 * 1024)
+    return if (mb == Math.floor(mb)) "${mb.toLong()}MB" else String.format(Locale.US, "%.1fMB", mb)
+}
+
+/**
+ * Product copy for one refusal.
+ *
+ * A reason whose copy names a limit falls back to the generic line when no limits are known, the
+ * same way the harness does: a sentence with a hole in it is worse than a vaguer sentence.
+ *
+ * @param limits the session's `imageLimits` projection, when it has arrived.
+ * @param rawReason the wire `details.reason` when the refusal came from the host, so an
+ *   [ImageRejection.UNKNOWN] can still carry something a bug report can act on.
+ */
+internal fun imageRejectionText(
+    context: Context,
+    rejection: ImageRejection,
+    limits: ImageLimitsView?,
+    rawReason: String? = null,
+): String = when (rejection) {
+    ImageRejection.UNSUPPORTED_TYPE -> context.getString(R.string.err_image_unsupported_type)
+    ImageRejection.MODEL_UNSUPPORTED -> context.getString(R.string.err_image_model_unsupported)
+    ImageRejection.SUBAGENT_UNSUPPORTED -> context.getString(R.string.err_image_subagent_unsupported)
+    ImageRejection.TOO_MANY_PIXELS -> context.getString(R.string.err_image_pixels)
+    ImageRejection.TOO_LARGE -> limits
+        ?.let { context.getString(R.string.err_image_too_large, imageSizeText(it.maxImageBytes)) }
+        ?: sendFailed(context, rawReason)
+    ImageRejection.BATCH_TOO_LARGE -> limits
+        ?.let { context.getString(R.string.err_image_batch_too_large, imageSizeText(it.maxMessageImageBytes)) }
+        ?: sendFailed(context, rawReason)
+    ImageRejection.TOO_MANY -> limits
+        ?.let { context.getString(R.string.err_image_too_many, it.maxImagesPerMessage) }
+        ?: sendFailed(context, rawReason)
+    ImageRejection.DIMENSION_TOO_LARGE -> limits
+        ?.let { context.getString(R.string.err_image_dimension, it.maxImageDimension) }
+        ?: sendFailed(context, rawReason)
+    ImageRejection.UNKNOWN -> sendFailed(context, rawReason)
+}
+
+private fun sendFailed(context: Context, rawReason: String?): String =
+    context.getString(R.string.err_image_send_failed, rawReason ?: "unknown")

--- a/app/src/main/java/com/labteto/dshmobile/ui/screens/main/SlashAdjudication.kt
+++ b/app/src/main/java/com/labteto/dshmobile/ui/screens/main/SlashAdjudication.kt
@@ -14,6 +14,23 @@ internal sealed interface Submission {
 
     /** Ordinary user text — including a `/skill-name` line, which the host resolves itself. */
     data class Prompt(val text: String) : Submission
+
+    /**
+     * The line names a command that cannot take the attached images. Nothing is sent: the draft
+     * and the images both stay in the composer behind a notice, which is what the harness's own
+     * client does — a submission that cannot be honoured whole is not quietly reshaped into one
+     * that can.
+     */
+    data class Refused(val command: String, val reason: RefusalReason) : Submission
+}
+
+/** Why a command line refused the composer's attachments. */
+internal enum class RefusalReason {
+    /** The command itself declares no image acceptance — most of them. */
+    COMMAND_TAKES_NO_IMAGES,
+
+    /** The command would take them, but this harness predates the wire that carries them. */
+    HOST_TOO_OLD,
 }
 
 /**
@@ -26,17 +43,26 @@ internal sealed interface Submission {
  * Adjudicating against the catalog first is what keeps a skill that shares a name with a command
  * resolving to the command.
  *
+ * Images are adjudicated here for the same reason the harness adjudicates them in its composer:
+ * the host refuses them per command, and a refusal that arrived after dispatch would have already
+ * cost the user their draft. Before harness 0.1.0-rc.8 no command took images at all and this
+ * client silently demoted such a line to a prompt — which sent `/goal` to the model as the literal
+ * text `/goal`, with nothing on screen to say so.
+ *
  * @param draft the composer's raw text.
  * @param catalog the session's command catalog (`commands/list`); empty means every line is a prompt.
- * @param hasAttachments true when images ride along — a command line takes no attachments.
+ * @param attachments how many images ride along.
+ * @param hostAcceptsImages whether this harness's `commands/execute` carries images at all
+ *   (`DshApiClient.acceptsCommandImages`).
  */
 internal fun adjudicate(
     draft: String,
     catalog: List<CommandDescriptor>,
-    hasAttachments: Boolean,
+    attachments: Int,
+    hostAcceptsImages: Boolean,
 ): Submission {
     val trimmed = draft.trim()
-    if (hasAttachments || !trimmed.startsWith("/")) return Submission.Prompt(draft)
+    if (!trimmed.startsWith("/")) return Submission.Prompt(draft)
 
     val separator = trimmed.indexOfFirst { it.isWhitespace() }
     val bare = separator == -1
@@ -49,7 +75,11 @@ internal fun adjudicate(
 
     // An argument-taking command claims the whole line; one that takes none only answers to a bare
     // invocation, so `/compact and then some` stays a prompt rather than silently dropping the tail.
-    if (descriptor.input != null) return Submission.Command(trimmed)
-    if (!bare) return Submission.Prompt(draft)
+    if (descriptor.input == null && !bare) return Submission.Prompt(draft)
+
+    if (attachments > 0) {
+        if (!descriptor.acceptsImages) return Submission.Refused(name, RefusalReason.COMMAND_TAKES_NO_IMAGES)
+        if (!hostAcceptsImages) return Submission.Refused(name, RefusalReason.HOST_TOO_OLD)
+    }
     return Submission.Command(trimmed)
 }

--- a/app/src/main/java/com/labteto/dshmobile/ui/screens/main/ToolRowModel.kt
+++ b/app/src/main/java/com/labteto/dshmobile/ui/screens/main/ToolRowModel.kt
@@ -3,6 +3,8 @@ package com.labteto.dshmobile.ui.screens.main
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.labteto.dshmobile.ui.components.FeatherIcons
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -54,7 +56,9 @@ private val TOOL_VARIANTS: Map<String, ToolRowVariant> = mapOf(
 private val SUMMARY_KEYS: Map<ToolRowVariant, List<String>> = mapOf(
     ToolRowVariant.Bash to listOf("description", "command"),
     ToolRowVariant.Read to listOf("path", "file_path", "url"),
-    ToolRowVariant.Search to listOf("query", "pattern", "url"),
+    // `queries` first: harness 0.1.0-rc.8 turned `web_search` into a 1-4 query array, and an
+    // rc.7 host still sends the singular `query` that grep and glob use anyway.
+    ToolRowVariant.Search to listOf("queries", "query", "pattern", "url"),
     ToolRowVariant.Write to listOf("path", "file_path"),
     ToolRowVariant.Edit to listOf("path", "file_path"),
     ToolRowVariant.Code to listOf("description"),
@@ -110,7 +114,7 @@ internal fun toolRowModel(
     val arguments = parseArguments(argumentsJson)
     val derived = SUMMARY_KEYS[variant]
         .orEmpty()
-        .firstNotNullOfOrNull { key -> arguments?.get(key).asString()?.takeIf { it.isNotBlank() } }
+        .firstNotNullOfOrNull { key -> arguments?.get(key).asSummary()?.takeIf { it.isNotBlank() } }
     val relative = derived?.let { relativizeToCwd(it, cwd) }
     // An unclassified tool with no presenter title would otherwise render as a bare "Tool call"
     // with nothing identifying it, so its raw name carries the summary instead.
@@ -148,6 +152,18 @@ private fun filePathOf(variant: ToolRowVariant, arguments: JsonObject?): String?
     ToolRowVariant.Read, ToolRowVariant.Write, ToolRowVariant.Edit ->
         listOf("path", "file_path").firstNotNullOfOrNull { arguments?.get(it).asString() }
     else -> null
+}
+
+/**
+ * The identifying argument as one line. A plain string is itself; an array of strings is joined
+ * the way the harness's own presenter joins `web_search`'s queries, so a multi-query search reads
+ * as one row rather than losing its subject entirely.
+ */
+private fun JsonElement?.asSummary(): String? = when (this) {
+    is JsonArray -> mapNotNull { it.asString()?.takeIf(String::isNotBlank) }
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString(", ")
+    else -> asString()
 }
 
 /** Tool arguments arrive as a raw JSON string; a malformed one simply yields no summary. */

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -255,6 +255,17 @@
     <string name="err_command_unknown">أمر غير معروف: %1$s</string>
     <string name="err_command_failed">فشل الأمر: %1$s</string>
     <string name="err_attachment_failed">تعذر إرفاق هذه الصورة.</string>
+    <string name="err_image_unsupported_type">لا تُدعم سوى صور PNG وJPG وWebP وGIF.</string>
+    <string name="err_image_too_large">يجب أن يكون حجم كل صورة أقل من %1$s.</string>
+    <string name="err_image_pixels">دقة هذه الصورة عالية جدًا. اضغطها ثم أعد المحاولة.</string>
+    <string name="err_image_dimension">يجب ألا يتجاوز طول ضلع الصورة %1$dpx. صغّرها ثم أعد المحاولة.</string>
+    <string name="err_image_too_many">يمكن أن تتضمن الرسالة %1$d صور كحد أقصى.</string>
+    <string name="err_image_batch_too_large">يتجاوز مجموع هذه الصور %1$s. أزل بعضها ثم أعد المحاولة.</string>
+    <string name="err_image_model_unsupported">هذا النموذج لا يقبل الصور. بدّل إلى نموذج يقبلها.</string>
+    <string name="err_image_subagent_unsupported">جلسات الوكيل الفرعي لا تقبل الصور.</string>
+    <string name="err_image_send_failed">تعذّر إرسال الصورة (%1$s). أعد إرفاقها ثم حاول مجددًا.</string>
+    <string name="err_command_no_images">/%1$s لا يقبل الصور المرفقة. أزلها أولًا.</string>
+    <string name="err_command_images_host">/%1$s لا يمكنه حمل الصور إلا على harness 0.1.0-rc.8 أو أحدث. أزلها أولًا.</string>
     <string name="err_permission_denied">هذا الإجراء متاح فقط على جهاز كمبيوتر Harness نفسه.</string>
     <string name="err_timeout">لم يجب Harness في الوقت المحدد.</string>
     <string name="err_generic">خطأ: %1$s</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -255,6 +255,17 @@
     <string name="err_command_unknown">অজানা কমান্ড: %1$s</string>
     <string name="err_command_failed">কমান্ড ব্যর্থ হয়েছে: %1$s</string>
     <string name="err_attachment_failed">ছবিটি সংযুক্ত করা যায়নি।</string>
+    <string name="err_image_unsupported_type">কেবল PNG, JPG, WebP ও GIF ছবি সমর্থিত।</string>
+    <string name="err_image_too_large">প্রতিটি ছবি %1$s-এর কম হতে হবে।</string>
+    <string name="err_image_pixels">এই ছবির রেজোলিউশন খুব বেশি। সংকুচিত করে আবার চেষ্টা করুন।</string>
+    <string name="err_image_dimension">ছবির বাহু সর্বাধিক %1$dpx হতে পারে। ছোট করে আবার চেষ্টা করুন।</string>
+    <string name="err_image_too_many">একটি বার্তায় সর্বাধিক %1$dটি ছবি দেওয়া যায়।</string>
+    <string name="err_image_batch_too_large">এই ছবিগুলি মিলে %1$s ছাড়িয়ে গেছে। কয়েকটি সরিয়ে আবার চেষ্টা করুন।</string>
+    <string name="err_image_model_unsupported">এই মডেল ছবি নেয় না। এমন একটি মডেল বেছে নিন যেটি নেয়।</string>
+    <string name="err_image_subagent_unsupported">সাবএজেন্ট সেশন ছবি নেয় না।</string>
+    <string name="err_image_send_failed">ছবি পাঠানো যায়নি (%1$s)। আবার যুক্ত করে চেষ্টা করুন।</string>
+    <string name="err_command_no_images">/%1$s ছবি সংযুক্তি নেয় না। আগে সেগুলি সরান।</string>
+    <string name="err_command_images_host">/%1$s কেবল harness 0.1.0-rc.8 বা তার নতুন সংস্করণে ছবি বহন করতে পারে। আগে সেগুলি সরান।</string>
     <string name="err_permission_denied">এই কাজটি শুধুমাত্র Harness কম্পিউটারেই উপলব্ধ।</string>
     <string name="err_timeout">Harness সময়মতো উত্তর দেয়নি।</string>
     <string name="err_generic">ত্রুটি: %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -255,6 +255,17 @@
     <string name="err_command_unknown">Comando desconocido: %1$s</string>
     <string name="err_command_failed">El comando falló: %1$s</string>
     <string name="err_attachment_failed">No se pudo adjuntar esa imagen.</string>
+    <string name="err_image_unsupported_type">Solo se admiten imágenes PNG, JPG, WebP y GIF.</string>
+    <string name="err_image_too_large">Cada imagen debe pesar menos de %1$s.</string>
+    <string name="err_image_pixels">Esa imagen tiene una resolución demasiado alta. Comprímela e inténtalo de nuevo.</string>
+    <string name="err_image_dimension">Los lados de la imagen no pueden superar los %1$dpx. Redúcela e inténtalo de nuevo.</string>
+    <string name="err_image_too_many">Un mensaje puede incluir como máximo %1$d imágenes.</string>
+    <string name="err_image_batch_too_large">Estas imágenes suman más de %1$s. Quita algunas e inténtalo de nuevo.</string>
+    <string name="err_image_model_unsupported">Este modelo no acepta imágenes. Cambia a uno que sí las acepte.</string>
+    <string name="err_image_subagent_unsupported">Las sesiones de subagente no aceptan imágenes.</string>
+    <string name="err_image_send_failed">No se pudo enviar la imagen (%1$s). Vuelve a adjuntarla e inténtalo de nuevo.</string>
+    <string name="err_command_no_images">/%1$s no acepta imágenes adjuntas. Quítalas primero.</string>
+    <string name="err_command_images_host">/%1$s solo puede llevar imágenes en harness 0.1.0-rc.8 o posterior. Quítalas primero.</string>
     <string name="err_permission_denied">Esta acción solo está disponible en el propio ordenador del Harness.</string>
     <string name="err_timeout">El Harness no respondió a tiempo.</string>
     <string name="err_generic">Error: %1$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -255,6 +255,17 @@
     <string name="err_command_unknown">Commande inconnue : %1$s</string>
     <string name="err_command_failed">La commande a échoué : %1$s</string>
     <string name="err_attachment_failed">Impossible de joindre cette image.</string>
+    <string name="err_image_unsupported_type">Seules les images PNG, JPG, WebP et GIF sont prises en charge.</string>
+    <string name="err_image_too_large">Chaque image doit peser moins de %1$s.</string>
+    <string name="err_image_pixels">La résolution de cette image est trop élevée. Compressez-la et réessayez.</string>
+    <string name="err_image_dimension">Les côtés de l\'image ne doivent pas dépasser %1$dpx. Réduisez-la et réessayez.</string>
+    <string name="err_image_too_many">Un message peut contenir au maximum %1$d images.</string>
+    <string name="err_image_batch_too_large">Ces images dépassent %1$s au total. Retirez-en quelques-unes et réessayez.</string>
+    <string name="err_image_model_unsupported">Ce modèle n\'accepte pas les images. Passez à un modèle qui les accepte.</string>
+    <string name="err_image_subagent_unsupported">Les sessions de sous-agent n\'acceptent pas les images.</string>
+    <string name="err_image_send_failed">L\'envoi de l\'image a échoué (%1$s). Rajoutez-la et réessayez.</string>
+    <string name="err_command_no_images">/%1$s n\'accepte pas les images jointes. Retirez-les d\'abord.</string>
+    <string name="err_command_images_host">/%1$s ne peut porter des images que sur harness 0.1.0-rc.8 ou plus récent. Retirez-les d\'abord.</string>
     <string name="err_permission_denied">Cette action n’est disponible que sur l’ordinateur du Harness lui-même.</string>
     <string name="err_timeout">Le Harness n’a pas répondu à temps.</string>
     <string name="err_generic">Erreur : %1$s</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -255,6 +255,17 @@
     <string name="err_command_unknown">अज्ञात कमांड: %1$s</string>
     <string name="err_command_failed">कमांड विफल: %1$s</string>
     <string name="err_attachment_failed">वह छवि संलग्न नहीं की जा सकी।</string>
+    <string name="err_image_unsupported_type">केवल PNG, JPG, WebP और GIF छवियाँ समर्थित हैं।</string>
+    <string name="err_image_too_large">हर छवि %1$s से छोटी होनी चाहिए।</string>
+    <string name="err_image_pixels">इस छवि का रिज़ॉल्यूशन बहुत अधिक है। इसे संपीड़ित करके फिर आज़माएँ।</string>
+    <string name="err_image_dimension">छवि की भुजाएँ अधिकतम %1$dpx हो सकती हैं। इसे छोटा करके फिर आज़माएँ।</string>
+    <string name="err_image_too_many">एक संदेश में अधिकतम %1$d छवियाँ भेजी जा सकती हैं।</string>
+    <string name="err_image_batch_too_large">ये छवियाँ कुल मिलाकर %1$s से अधिक हैं। कुछ हटाकर फिर आज़माएँ।</string>
+    <string name="err_image_model_unsupported">यह मॉडल छवियाँ स्वीकार नहीं करता। ऐसा मॉडल चुनें जो करता हो।</string>
+    <string name="err_image_subagent_unsupported">सबएजेंट सत्र छवियाँ स्वीकार नहीं करते।</string>
+    <string name="err_image_send_failed">छवि भेजी नहीं जा सकी (%1$s)। इसे दोबारा जोड़कर फिर आज़माएँ।</string>
+    <string name="err_command_no_images">/%1$s छवि अनुलग्नक स्वीकार नहीं करता। पहले उन्हें हटाएँ।</string>
+    <string name="err_command_images_host">/%1$s केवल harness 0.1.0-rc.8 या उससे नए पर छवियाँ ले जा सकता है। पहले उन्हें हटाएँ।</string>
     <string name="err_permission_denied">यह कार्रवाई केवल Harness कंप्यूटर पर ही उपलब्ध है।</string>
     <string name="err_timeout">Harness ने समय पर उत्तर नहीं दिया।</string>
     <string name="err_generic">त्रुटि: %1$s</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -255,6 +255,17 @@
     <string name="err_command_unknown">Comando desconhecido: %1$s</string>
     <string name="err_command_failed">O comando falhou: %1$s</string>
     <string name="err_attachment_failed">Não foi possível anexar essa imagem.</string>
+    <string name="err_image_unsupported_type">Só há suporte para imagens PNG, JPG, WebP e GIF.</string>
+    <string name="err_image_too_large">Cada imagem deve ter menos de %1$s.</string>
+    <string name="err_image_pixels">A resolução dessa imagem é alta demais. Comprima-a e tente novamente.</string>
+    <string name="err_image_dimension">Os lados da imagem não podem passar de %1$dpx. Reduza-a e tente novamente.</string>
+    <string name="err_image_too_many">Uma mensagem pode incluir no máximo %1$d imagens.</string>
+    <string name="err_image_batch_too_large">Estas imagens somam mais de %1$s. Remova algumas e tente novamente.</string>
+    <string name="err_image_model_unsupported">Este modelo não aceita imagens. Troque para um que aceite.</string>
+    <string name="err_image_subagent_unsupported">Sessões de subagente não aceitam imagens.</string>
+    <string name="err_image_send_failed">Não foi possível enviar a imagem (%1$s). Anexe-a novamente e tente de novo.</string>
+    <string name="err_command_no_images">/%1$s não aceita imagens anexadas. Remova-as primeiro.</string>
+    <string name="err_command_images_host">/%1$s só pode levar imagens no harness 0.1.0-rc.8 ou mais recente. Remova-as primeiro.</string>
     <string name="err_permission_denied">Esta ação está disponível apenas no próprio computador do Harness.</string>
     <string name="err_timeout">O Harness não respondeu a tempo.</string>
     <string name="err_generic">Erro: %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -255,6 +255,17 @@
     <string name="err_command_unknown">Неизвестная команда: %1$s</string>
     <string name="err_command_failed">Команда не выполнена: %1$s</string>
     <string name="err_attachment_failed">Не удалось прикрепить это изображение.</string>
+    <string name="err_image_unsupported_type">Поддерживаются только изображения PNG, JPG, WebP и GIF.</string>
+    <string name="err_image_too_large">Каждое изображение должно быть меньше %1$s.</string>
+    <string name="err_image_pixels">Слишком высокое разрешение изображения. Сожмите его и попробуйте снова.</string>
+    <string name="err_image_dimension">Стороны изображения не должны превышать %1$dpx. Уменьшите его и попробуйте снова.</string>
+    <string name="err_image_too_many">В одном сообщении можно отправить не более %1$d изображений.</string>
+    <string name="err_image_batch_too_large">Суммарный размер изображений превышает %1$s. Удалите часть и попробуйте снова.</string>
+    <string name="err_image_model_unsupported">Эта модель не принимает изображения. Переключитесь на ту, которая принимает.</string>
+    <string name="err_image_subagent_unsupported">Сессии субагента не принимают изображения.</string>
+    <string name="err_image_send_failed">Не удалось отправить изображение (%1$s). Прикрепите его заново и попробуйте снова.</string>
+    <string name="err_command_no_images">/%1$s не принимает вложенные изображения. Сначала удалите их.</string>
+    <string name="err_command_images_host">/%1$s может передавать изображения только на harness 0.1.0-rc.8 или новее. Сначала удалите их.</string>
     <string name="err_permission_denied">Это действие доступно только на самом компьютере с Harness.</string>
     <string name="err_timeout">Harness не ответил вовремя.</string>
     <string name="err_generic">Ошибка: %1$s</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -255,6 +255,17 @@
     <string name="err_command_unknown">คำสั่งไม่รู้จัก: %1$s</string>
     <string name="err_command_failed">คำสั่งล้มเหลว: %1$s</string>
     <string name="err_attachment_failed">ไม่สามารถแนบรูปภาพนั้นได้</string>
+    <string name="err_image_unsupported_type">รองรับเฉพาะรูปภาพ PNG, JPG, WebP และ GIF</string>
+    <string name="err_image_too_large">รูปภาพแต่ละรูปต้องมีขนาดเล็กกว่า %1$s</string>
+    <string name="err_image_pixels">รูปภาพนี้มีความละเอียดสูงเกินไป โปรดบีบอัดแล้วลองใหม่</string>
+    <string name="err_image_dimension">ด้านของรูปภาพต้องไม่เกิน %1$dpx โปรดย่อขนาดแล้วลองใหม่</string>
+    <string name="err_image_too_many">หนึ่งข้อความแนบรูปภาพได้สูงสุด %1$d รูป</string>
+    <string name="err_image_batch_too_large">รูปภาพเหล่านี้รวมกันเกิน %1$s โปรดลบออกบางรูปแล้วลองใหม่</string>
+    <string name="err_image_model_unsupported">โมเดลนี้ไม่รับรูปภาพ โปรดเปลี่ยนไปใช้โมเดลที่รับได้</string>
+    <string name="err_image_subagent_unsupported">เซสชันซับเอเจนต์ไม่รับรูปภาพ</string>
+    <string name="err_image_send_failed">ส่งรูปภาพไม่สำเร็จ (%1$s) โปรดแนบใหม่แล้วลองอีกครั้ง</string>
+    <string name="err_command_no_images">/%1$s ไม่รับไฟล์รูปภาพแนบ โปรดลบออกก่อน</string>
+    <string name="err_command_images_host">/%1$s แนบรูปภาพได้เฉพาะบน harness 0.1.0-rc.8 ขึ้นไป โปรดลบออกก่อน</string>
     <string name="err_permission_denied">การดำเนินการนี้ใช้ได้เฉพาะบนคอมพิวเตอร์ของ Harness เท่านั้น</string>
     <string name="err_timeout">Harness ไม่ตอบกลับทันเวลา</string>
     <string name="err_generic">ข้อผิดพลาด: %1$s</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -255,6 +255,17 @@
     <string name="err_command_unknown">نامعلوم کمانڈ: %1$s</string>
     <string name="err_command_failed">کمانڈ ناکام: %1$s</string>
     <string name="err_attachment_failed">وہ تصویر منسلک نہیں ہو سکی۔</string>
+    <string name="err_image_unsupported_type">صرف PNG، JPG، WebP اور GIF تصاویر معاون ہیں۔</string>
+    <string name="err_image_too_large">ہر تصویر %1$s سے چھوٹی ہونی چاہیے۔</string>
+    <string name="err_image_pixels">اس تصویر کی ریزولوشن بہت زیادہ ہے۔ اسے دبا کر دوبارہ کوشش کریں۔</string>
+    <string name="err_image_dimension">تصویر کے اطراف زیادہ سے زیادہ %1$dpx ہو سکتے ہیں۔ اسے چھوٹا کر کے دوبارہ کوشش کریں۔</string>
+    <string name="err_image_too_many">ایک پیغام میں زیادہ سے زیادہ %1$d تصاویر شامل کی جا سکتی ہیں۔</string>
+    <string name="err_image_batch_too_large">یہ تصاویر مل کر %1$s سے زیادہ ہیں۔ کچھ ہٹا کر دوبارہ کوشش کریں۔</string>
+    <string name="err_image_model_unsupported">یہ ماڈل تصاویر قبول نہیں کرتا۔ ایسا ماڈل منتخب کریں جو کرتا ہو۔</string>
+    <string name="err_image_subagent_unsupported">سب ایجنٹ سیشنز تصاویر قبول نہیں کرتے۔</string>
+    <string name="err_image_send_failed">تصویر بھیجی نہیں جا سکی (%1$s)۔ دوبارہ منسلک کر کے کوشش کریں۔</string>
+    <string name="err_command_no_images">/%1$s تصویری منسلکات قبول نہیں کرتا۔ پہلے انہیں ہٹا دیں۔</string>
+    <string name="err_command_images_host">/%1$s صرف harness 0.1.0-rc.8 یا اس سے نئے پر تصاویر لے جا سکتا ہے۔ پہلے انہیں ہٹا دیں۔</string>
     <string name="err_permission_denied">یہ کارروائی صرف Harness کے کمپیوٹر پر ہی دستیاب ہے۔</string>
     <string name="err_timeout">Harness نے بروقت جواب نہیں دیا۔</string>
     <string name="err_generic">خرابی: %1$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -255,6 +255,17 @@
     <string name="err_command_unknown">未知命令：%1$s</string>
     <string name="err_command_failed">命令失败：%1$s</string>
     <string name="err_attachment_failed">无法附加该图片。</string>
+    <string name="err_image_unsupported_type">仅支持 PNG、JPG、WebP、GIF 格式的图片。</string>
+    <string name="err_image_too_large">单张图片不能超过 %1$s。</string>
+    <string name="err_image_pixels">该图片分辨率过大，请压缩后重试。</string>
+    <string name="err_image_dimension">图片宽高不能超过 %1$dpx，请缩小后重试。</string>
+    <string name="err_image_too_many">一条消息最多添加 %1$d 张图片。</string>
+    <string name="err_image_batch_too_large">图片总大小超过 %1$s，请移除部分图片。</string>
+    <string name="err_image_model_unsupported">当前模型不支持图片，请切换支持图片的模型。</string>
+    <string name="err_image_subagent_unsupported">子智能体会话暂不支持图片。</string>
+    <string name="err_image_send_failed">图片发送失败（%1$s），请重新添加后再试。</string>
+    <string name="err_command_no_images">/%1$s 不接受图片附件，请先移除图片。</string>
+    <string name="err_command_images_host">/%1$s 只能在 harness 0.1.0-rc.8 及更新版本上携带图片，请先移除图片。</string>
     <string name="err_permission_denied">此操作仅在 Harness 所在电脑上可用。</string>
     <string name="err_timeout">Harness 未及时响应。</string>
     <string name="err_generic">错误：%1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,6 +326,17 @@
     <string name="err_command_unknown">Unknown command: %1$s</string>
     <string name="err_command_failed">Command failed: %1$s</string>
     <string name="err_attachment_failed">Could not attach that image.</string>
+    <string name="err_image_unsupported_type">Only PNG, JPG, WebP and GIF images are supported.</string>
+    <string name="err_image_too_large">Each image must be smaller than %1$s.</string>
+    <string name="err_image_pixels">That image\'s resolution is too high. Compress it and try again.</string>
+    <string name="err_image_dimension">Image sides must be at most %1$dpx. Downscale it and try again.</string>
+    <string name="err_image_too_many">A message can include up to %1$d images.</string>
+    <string name="err_image_batch_too_large">These images exceed %1$s in total. Remove some and try again.</string>
+    <string name="err_image_model_unsupported">This model does not take images. Switch to one that does.</string>
+    <string name="err_image_subagent_unsupported">Subagent sessions do not take images.</string>
+    <string name="err_image_send_failed">Sending the image failed (%1$s). Re-add it and try again.</string>
+    <string name="err_command_no_images">/%1$s does not take image attachments. Remove them first.</string>
+    <string name="err_command_images_host">/%1$s can carry images only on harness 0.1.0-rc.8 or newer. Remove them first.</string>
     <string name="err_permission_denied">This action is only available on the harness computer itself.</string>
     <string name="err_timeout">The harness did not answer in time.</string>
     <string name="err_generic">Error: %1$s</string>

--- a/app/src/test/java/com/labteto/dshmobile/ui/screens/main/ImageErrorCopyTest.kt
+++ b/app/src/test/java/com/labteto/dshmobile/ui/screens/main/ImageErrorCopyTest.kt
@@ -1,0 +1,26 @@
+package com.labteto.dshmobile.ui.screens.main
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The size a limit is reported at.
+ *
+ * The harness writes its own attachment bounds this way, and the two sides of a refusal have to
+ * agree: an image the client turns away for exceeding "3.5MB" must not come back from the host
+ * named as 3670016 bytes, or the same limit reads as two different ones.
+ */
+class ImageErrorCopyTest {
+
+    @Test
+    fun `a whole number of megabytes loses its decimal`() {
+        assertEquals("100MB", imageSizeText(104_857_600))
+        assertEquals("5MB", imageSizeText(5_242_880))
+    }
+
+    @Test
+    fun `a fractional size keeps one place`() {
+        // The shipped per-image cap at harness 0.1.0-rc.8.
+        assertEquals("3.5MB", imageSizeText(3_670_016))
+    }
+}

--- a/app/src/test/java/com/labteto/dshmobile/ui/screens/main/SlashAdjudicationTest.kt
+++ b/app/src/test/java/com/labteto/dshmobile/ui/screens/main/SlashAdjudicationTest.kt
@@ -21,15 +21,16 @@ class SlashAdjudicationTest {
             description = "Switch the permission preset",
             input = CommandInputDescriptor(hint = "<preset>"),
         ),
+        // `/goal` and `/plan` are the two commands harness 0.1.0-rc.8 taught to take images.
         CommandDescriptor(
             name = "goal",
             description = "Set a goal",
-            input = CommandInputDescriptor(hint = "<text>"),
+            input = CommandInputDescriptor(hint = "<text>", images = true),
         ),
     )
 
-    private fun decide(draft: String, attachments: Boolean = false) =
-        adjudicate(draft, catalog, attachments)
+    private fun decide(draft: String, attachments: Int = 0, hostAcceptsImages: Boolean = true) =
+        adjudicate(draft, catalog, attachments, hostAcceptsImages)
 
     @Test
     fun `ordinary text is a prompt`() {
@@ -86,12 +87,57 @@ class SlashAdjudicationTest {
 
     @Test
     fun `an empty catalog makes every line a prompt`() {
-        assertEquals(Submission.Prompt("/compact"), adjudicate("/compact", emptyList(), false))
+        assertEquals(Submission.Prompt("/compact"), adjudicate("/compact", emptyList(), 0, true))
     }
 
     @Test
-    fun `attachments force the prompt path`() {
-        // A command line takes no images, and the prompt API is the only thing that carries them.
-        assertEquals(Submission.Prompt("/compact"), decide("/compact", attachments = true))
+    fun `a command that declares images takes them`() {
+        assertEquals(Submission.Command("/goal ship it"), decide("/goal ship it", attachments = 1))
+    }
+
+    @Test
+    fun `a command that declares no images refuses them rather than becoming a prompt`() {
+        // This used to send the literal text "/compact" to the model alongside the picture, with
+        // nothing on screen to say the command had been quietly demoted.
+        assertEquals(
+            Submission.Refused("compact", RefusalReason.COMMAND_TAKES_NO_IMAGES),
+            decide("/compact", attachments = 1),
+        )
+        assertEquals(
+            Submission.Refused("permission", RefusalReason.COMMAND_TAKES_NO_IMAGES),
+            decide("/permission read-only", attachments = 1),
+        )
+    }
+
+    @Test
+    fun `a harness that cannot carry images says so rather than dropping them`() {
+        assertEquals(
+            Submission.Refused("goal", RefusalReason.HOST_TOO_OLD),
+            decide("/goal ship it", attachments = 1, hostAcceptsImages = false),
+        )
+        // Without images the same command is unremarkable on either release.
+        assertEquals(
+            Submission.Command("/goal ship it"),
+            decide("/goal ship it", hostAcceptsImages = false),
+        )
+    }
+
+    @Test
+    fun `the catalog is consulted before the images are`() {
+        // An unregistered name is a skill, and a skill is invoked by sending it as a prompt — so
+        // it keeps its images and goes to the model, exactly as it does without them.
+        assertEquals(Submission.Prompt("/my-skill do it"), decide("/my-skill do it", attachments = 1))
+        // And a command that never claimed the line does not get to refuse it either.
+        assertEquals(
+            Submission.Prompt("/compact and summarise"),
+            decide("/compact and summarise", attachments = 1),
+        )
+    }
+
+    @Test
+    fun `sub-command grammar is left to the host`() {
+        // `/plan off` with images is refused by the handler, not the composer — mirroring the rule
+        // here would mean maintaining a copy of every command's grammar.
+        assertEquals(Submission.Command("/goal clear"), decide("/goal clear", attachments = 1))
     }
 }

--- a/app/src/test/java/com/labteto/dshmobile/ui/screens/main/ToolRowModelTest.kt
+++ b/app/src/test/java/com/labteto/dshmobile/ui/screens/main/ToolRowModelTest.kt
@@ -11,6 +11,33 @@ import org.junit.Test
 class ToolRowModelTest {
 
     @Test
+    fun `a web search shows its queries, however many the model asked for`() {
+        // Harness 0.1.0-rc.8 turned `web_search`'s single `query` into a 1-4 element `queries`
+        // array. Reading only the old key left the row saying "Search" and nothing else.
+        val one = toolRowModel(
+            toolName = "web_search",
+            argumentsJson = """{"queries":["deepseek harness architecture"]}""",
+            cwd = null,
+        )
+        assertEquals("deepseek harness architecture", one.summary)
+
+        val several = toolRowModel(
+            toolName = "web_search",
+            argumentsJson = """{"queries":["kotlin coroutines","structured concurrency"]}""",
+            cwd = null,
+        )
+        assertEquals("kotlin coroutines, structured concurrency", several.summary)
+
+        // An older harness still sends the singular key, and grep and glob always did.
+        val older = toolRowModel(
+            toolName = "web_search",
+            argumentsJson = """{"query":"just the one"}""",
+            cwd = null,
+        )
+        assertEquals("just the one", older.summary)
+    }
+
+    @Test
     fun `a read shows the verb and a path relative to the session cwd`() {
         val row = toolRowModel(
             toolName = "read",

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/DshCore.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/DshCore.kt
@@ -2,5 +2,12 @@ package com.labteto.dshmobile.core
 
 /** Core module placeholder for the baseline build; wire protocol code lands here. */
 object DshCore {
-    const val PROTOCOL_BASELINE = "0.1.0-rc.7"
+    /**
+     * The harness release this client's DTOs and call shapes were ported from and verified
+     * against. Display-only: nothing is gated on it, and the app never compares it against
+     * `host.describe.version` — see `docs/COMPATIBILITY.md`. Where a shape genuinely differs
+     * between releases the client reads the difference off the wire instead, as
+     * `DshApiClient.acceptsCommandImages` does.
+     */
+    const val PROTOCOL_BASELINE = "0.1.0-rc.8"
 }

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/session/EventFold.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/session/EventFold.kt
@@ -19,8 +19,10 @@ import kotlinx.serialization.json.longOrNull
  *  - assistant streaming: `assistant/chunk` deltas merge per block index;
  *    `block-end` carries the assembled block; `assistant/message` is the
  *    commit point (and authoritative when no chunks were seen).
- *  - `turn/end` with reason kind `interrupted`/`aborted` marks the open
- *    assistant node of that turn.
+ *  - interruption: harness 0.1.0-rc.8 marks a cancelled turn's finalized prefix
+ *    on the `assistant/message` itself, and that wins; a `turn/end` whose reason
+ *    kind is `interrupted`/`aborted`/`error` marks the turn's assistant node
+ *    otherwise, which is all an rc.7 host gives.
  *  - unknown event types become [OtherNode] (merge-extensible contract).
  *
  * The fold is pure: same events → same snapshot.
@@ -138,6 +140,11 @@ private class FoldState(private val sessionId: String) {
                 val message = data.jsonObject["message"]?.jsonObject
                 val messageId = message?.get("id")?.jsonPrimitive?.contentOrNull
                 val usage = data.jsonObject["usage"]
+                // Harness 0.1.0-rc.8 finalises a cancelled turn's delivered prefix as an ordinary
+                // `assistant/message` carrying this marker, which is authoritative. Before rc.8
+                // the host appended nothing at all and the prefix was simply lost, so the absence
+                // of the key is not "not interrupted" — see markInterrupted.
+                val interrupted = data.jsonObject["interrupted"]?.jsonPrimitive?.booleanOrNull ?: false
                 val key = key(turn, step)
                 val open = openByKey[key]
                 val blocks = when {
@@ -146,7 +153,9 @@ private class FoldState(private val sessionId: String) {
                 }
                 openByKey.remove(key)
                 if (nodes.none { it is AssistantMessageNode && it.seq == event.seq }) {
-                    nodes.add(AssistantMessageNode(event.seq, messageId, turn, step, blocks, usage))
+                    nodes.add(
+                        AssistantMessageNode(event.seq, messageId, turn, step, blocks, usage, interrupted),
+                    )
                 }
             }
 
@@ -307,7 +316,17 @@ private class FoldState(private val sessionId: String) {
         }
     }
 
+    /**
+     * Mark the turn's assistant answer as cut short, inferred from how the turn ended.
+     *
+     * This is the pre-rc.8 source of the fact and stays the only one an rc.7 host offers. When
+     * rc.8 marked the message itself, that marker is authoritative and this adds nothing, so it
+     * stands aside rather than re-marking. It does not — and from a pure fold cannot — fix the
+     * case where a turn is cancelled between steps: no message exists for the cancelled step, so
+     * the search lands on the previous, complete one. That was equally true before rc.8.
+     */
     private fun markInterrupted(turn: Int) {
+        if (nodes.any { it is AssistantMessageNode && it.turn == turn && it.interrupted }) return
         val index = nodes.indexOfLast { it is AssistantMessageNode && it.turn == turn }
         if (index >= 0) {
             val node = nodes[index] as AssistantMessageNode

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/ConnectionLoop.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/ConnectionLoop.kt
@@ -250,6 +250,9 @@ class ConnectionLoop(
             )
         }
 
+        // Describing is the last handshake step, and DshApiClient.hostDescribe latches this
+        // connection's command-image capability from the answer — so by the time anyone can
+        // reach a command through this client, its `commands/execute` shape is already decided.
         safeSink { sinks.onHandshakeStep(HandshakeStep.DESCRIBING) }
         return when (val describe = api.hostDescribe()) {
             is RpcResult.Ok -> Opened.Ok(

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/DshApiClient.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/DshApiClient.kt
@@ -19,6 +19,7 @@ import com.labteto.dshmobile.core.wire.dto.CredentialsSetValue
 import com.labteto.dshmobile.core.wire.dto.CredentialsUnsetRequest
 import com.labteto.dshmobile.core.wire.dto.CredentialsUnsetValue
 import com.labteto.dshmobile.core.wire.dto.DirectoryListing
+import com.labteto.dshmobile.core.wire.dto.EncodedImageAttachment
 import com.labteto.dshmobile.core.wire.dto.GoalClearRequest
 import com.labteto.dshmobile.core.wire.dto.GoalClearValue
 import com.labteto.dshmobile.core.wire.dto.GoalCompleteRequest
@@ -105,6 +106,7 @@ import java.io.InputStream
 import java.net.URLEncoder
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -118,7 +120,7 @@ private fun encodeQueryComponent(value: String): String =
     URLEncoder.encode(value, "UTF-8").replace("+", "%20")
 
 /**
- * Typed client for the harness unary + downlink wire protocol (v0.1.0-rc.7). Every unary method
+ * Typed client for the harness unary + downlink wire protocol (v0.1.0-rc.8). Every unary method
  * maps to one `POST /api/<method>` (see [rpcMapPath] for the path table) and returns [RpcResult]:
  * business failures arrive as HTTP 200 + `ok: false` and come back as [RpcResult.Err]; carrier
  * failures (non-2xx, transport, or decode) are folded into `RpcResult.Err` with code `internal`.
@@ -127,6 +129,18 @@ class DshApiClient(
     private val transport: RpcTransport,
     private val wsFactory: (path: String, sink: WsDownlinkSink) -> WsDownlink,
 ) {
+
+    /**
+     * Whether this host's `commands/execute` takes an `images` argument (harness 0.1.0-rc.8).
+     *
+     * Set once per connection generation by the handshake — see [ConnectionLoop] — from the
+     * *shape* of `host.describe` rather than its `version`, because a version string is the one
+     * thing this client has never been willing to branch on (`docs/COMPATIBILITY.md`). It is
+     * volatile because the handshake and the callers run on different threads.
+     */
+    @Volatile
+    var acceptsCommandImages: Boolean = false
+        private set
 
     // ------------------------------------------------------------------ unary machinery
 
@@ -195,8 +209,16 @@ class DshApiClient(
 
     // ------------------------------------------------------------------ host
 
-    /** host.describe — one-shot host snapshot. */
-    suspend fun hostDescribe(): RpcResult<HostDescription> = callEmpty("host.describe")
+    /**
+     * host.describe — one-shot host snapshot, and the point where [acceptsCommandImages] is
+     * latched. Every path that reaches this client's commands describes first (the handshake's
+     * last step, `ConnectionLoop.openGeneration`), so latching here rather than at one call site
+     * means no caller can dispatch a command against an undecided shape.
+     */
+    suspend fun hostDescribe(): RpcResult<HostDescription> =
+        callEmpty<HostDescription>("host.describe").also { result ->
+            if (result is RpcResult.Ok) acceptsCommandImages = result.value.home != null
+        }
 
     /** host.pickDirectory — open the OS directory picker; `path` is null when the user cancelled. */
     suspend fun hostPickDirectory(): RpcResult<HostPickDirectoryValue> = callEmpty("host.pickDirectory")
@@ -487,16 +509,44 @@ class DshApiClient(
      *
      * [sessionPrompt] executes a leading-slash line the same way, so a caller that cannot reach the
      * gateway still has a working write path.
+     *
+     * The `images` argument arrived in harness 0.1.0-rc.8 and is *required* there. The gateway
+     * matches an args object against the remote's declared parameters and refuses both a missing
+     * and an unexpected key, so this is the one call in the client whose shape cannot be written
+     * once for every host: it follows [acceptsCommandImages], which the handshake sets from the
+     * shape of `host.describe` rather than from any version string.
+     *
+     * @param images base64-encoded composer images, in submission order; must be empty when
+     *   [acceptsCommandImages] is false, because an rc.7 host has nowhere to put them.
      */
-    suspend fun commandsExecute(sessionId: String, line: String): RpcResult<JsonElement> =
-        remote(
+    suspend fun commandsExecute(
+        sessionId: String,
+        line: String,
+        images: List<EncodedImageAttachment> = emptyList(),
+    ): RpcResult<JsonElement> {
+        // Refuse rather than drop. Adjudication should have stopped this already, but every other
+        // caller of this method reaches it directly, and silently sending a command without the
+        // images the user attached to it is the one outcome nobody could diagnose from the screen.
+        if (images.isNotEmpty() && !acceptsCommandImages) {
+            return RpcResult.Err(
+                RpcError(
+                    code = "capability-unavailable",
+                    message = "this harness does not carry image attachments on a command",
+                ),
+            )
+        }
+        return remote(
             "commands",
             "execute",
             buildJsonObject {
                 put("agentId", JsonPrimitive(sessionId))
                 put("line", JsonPrimitive(line))
+                if (acceptsCommandImages) {
+                    put("images", encodeToJsonElement(ListSerializer(EncodedImageAttachment.serializer()), images))
+                }
             },
         )
+    }
 
     /**
      * pluginInventory/list — the host's composed-plugin inventory (read-only).

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/Envelopes.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/Envelopes.kt
@@ -26,7 +26,7 @@ import kotlinx.serialization.json.put
 
 /**
  * The four wire full-form RPC message envelopes plus the result/error vocabulary, ported from
- * `packages/host/apiproxy/src/api/rpc.ts` and `rpc.schema.ts` (v0.1.0-rc.7).
+ * `packages/host/apiproxy/src/api/rpc.ts` and `rpc.schema.ts` (v0.1.0-rc.8).
  *
  * Wire forms:
  * - [ClientRequest]  — POST /api/<method> body (`type: "client-request"`).

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/AgentPresetDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/AgentPresetDtos.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Agent-preset DTOs, ported from `packages/host/apiproxy/src/api/agent-presets.schema.ts` and
- * `packages/host/apiproxy/src/api/agent-presets.ts` (v0.1.0-rc.7).
+ * `packages/host/apiproxy/src/api/agent-presets.ts` (v0.1.0-rc.8).
  */
 
 /** Trust tier of an agent preset. */

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/CommandDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/CommandDtos.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Slash-command DTOs, ported from `packages/interaction/commands/src/types.ts` (v0.1.0-rc.7).
+ * Slash-command DTOs, ported from `packages/interaction/commands/src/types.ts` (v0.1.0-rc.8).
  *
  * The catalog is read through the typert remote `commands/list`; it is per-session and
  * deployment-dependent (a preset switch changes which commands an agent resolves), so it is
@@ -15,6 +15,13 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CommandInputDescriptor(
     @SerialName("hint") val hint: String = "",
+    /**
+     * Whether composer image attachments may accompany an invocation (harness 0.1.0-rc.8; an
+     * rc.7 host sends no such key and the default stands). False means the executor refuses an
+     * invocation carrying images, so a capable composer refuses the submission before dispatch
+     * rather than quietly sending the line to the model instead.
+     */
+    @SerialName("images") val images: Boolean = false,
 )
 
 /**
@@ -32,4 +39,24 @@ data class CommandDescriptor(
 
     /** The draft prefix an argument-taking invocation prefills. */
     val draftPrefix: String get() = "/$name "
+
+    /** Whether this command accepts composer images (harness 0.1.0-rc.8; `/goal` and `/plan`). */
+    val acceptsImages: Boolean get() = input?.images == true
 }
+
+/**
+ * One base64-encoded image riding a wire request — the harness's `EncodedImageAttachment`
+ * (`packages/attachment/attachment/src/types.ts`).
+ *
+ * Deliberately not [PromptContentPart.Image]: that shape carries a `type` discriminator the
+ * command gateway's boundary codec does not declare, and the gateway validates its arguments
+ * against the declared shape rather than ignoring what it did not ask for.
+ */
+@Serializable
+data class EncodedImageAttachment(
+    @SerialName("mediaType") val mediaType: String,
+    /** Canonical base64 of the image bytes; the host verifies it against the declared type. */
+    @SerialName("data") val data: String,
+    /** Optional display name; never interpreted as a path. */
+    @SerialName("name") val name: String? = null,
+)

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/CredentialsDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/CredentialsDtos.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Credentials-domain DTOs, ported from `packages/host/apiproxy/src/api/credentials.schema.ts` and
- * `packages/host/apiproxy/src/api/credentials.ts` (v0.1.0-rc.7).
+ * `packages/host/apiproxy/src/api/credentials.ts` (v0.1.0-rc.8).
  */
 
 /** CredentialView entry of `credentials.describe`. */

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/Events.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/Events.kt
@@ -505,6 +505,13 @@ data class AssistantMessageData(
     @SerialName("message") val message: MessageData,
     /** Present when the adapter reported token accounting. */
     @SerialName("usage") val usage: TokenUsage? = null,
+    /**
+     * True when this message is the prefix a cancelled turn had already delivered, finalized so
+     * the partial answer survives (harness 0.1.0-rc.8; undispatched tool calls are absent). An
+     * rc.7 host sends no such key and appends no message at all, which is why the fold keeps a
+     * fallback that infers interruption from the turn's own ending.
+     */
+    @SerialName("interrupted") val interrupted: Boolean? = null,
 )
 
 /** `tool/call` payload — the model requested one tool invocation. */

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/Frames.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/Frames.kt
@@ -25,7 +25,7 @@ import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Downlink stream frame unions, ported exactly from `packages/host/apiproxy/src/api/events.ts`
- * (v0.1.0-rc.7). A frame is the payload slot of a downstream ServerRequest; dispatch on `type`.
+ * (v0.1.0-rc.8). A frame is the payload slot of a downstream ServerRequest; dispatch on `type`.
  * Unknown frame kinds fall back to [UnknownMuxFrame] / [UnknownHostFrame] preserving the raw JSON.
  */
 

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/GoalsDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/GoalsDtos.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Goals-domain DTOs, ported from `packages/host/apiproxy/src/api/goals.schema.ts` and
- * `packages/goal/goal/src/types.ts` (v0.1.0-rc.7). Mutations only: the read side is the
+ * `packages/goal/goal/src/types.ts` (v0.1.0-rc.8). Mutations only: the read side is the
  * 'goal' session projection; every non-clear mutation acknowledges with the new CAS ref.
  */
 

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/HostDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/HostDtos.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Host-domain DTOs, ported from `packages/host/apiproxy/src/api/host.schema.ts` (v0.1.0-rc.7).
+ * Host-domain DTOs, ported from `packages/host/apiproxy/src/api/host.schema.ts` (v0.1.0-rc.8).
  * Wire keys are camelCase exactly as the harness emits them.
  */
 
@@ -21,6 +21,13 @@ data class HostDescription(
     @SerialName("model") val model: String? = null,
     /** Count of currently attached sessions (those with a live agent). */
     @SerialName("attachedSessions") val attachedSessions: Int,
+    /**
+     * The host account's home directory. Required from harness 0.1.0-rc.8 and absent before it,
+     * which makes its presence the client's rc.8 signal — see [com.labteto.dshmobile.core.DshCore]
+     * and `docs/COMPATIBILITY.md`. Nullable so an rc.7 host still decodes, and so the handshake,
+     * which runs `host.describe` before anything else, cannot fail on a missing key.
+     */
+    @SerialName("home") val home: String? = null,
     /** Whether this deployment can hand a path to a user-visible native desktop. */
     @SerialName("canOpenPath") val canOpenPath: Boolean,
 )

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/LlmDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/LlmDtos.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * LLM-domain DTOs, ported from `packages/host/apiproxy/src/api/llm.schema.ts` and
- * `packages/host/apiproxy/src/api/llm.ts` (v0.1.0-rc.7). The model catalog shapes
+ * `packages/host/apiproxy/src/api/llm.ts` (v0.1.0-rc.8). The model catalog shapes
  * (ModelProviderGroup / ModelCatalogFailure) live in SessionsDtos.
  */
 

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/PermissionDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/PermissionDtos.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Permission-preset DTOs, ported from
- * `packages/interaction/permission-presets/src/types.ts` (v0.1.0-rc.7).
+ * `packages/interaction/permission-presets/src/types.ts` (v0.1.0-rc.8).
  *
  * The read side is the `permissions` session projection — no RPC. The write side is the
  * `/permission <value>` slash command. An absent projection key means no permission service is

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/ProjectionDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/ProjectionDtos.kt
@@ -78,21 +78,123 @@ data class ContextBreakdownView(
 }
 
 /**
+ * Why a host would refuse one image.
+ *
+ * The cases are the harness's own admission vocabulary (`packages/attachment/attachment/src/
+ * error.ts`), so one string table serves both the pre-check performed here and a rejection that
+ * still arrives from the host as an `attachment-error` — see [imageRejectionOf].
+ */
+enum class ImageRejection {
+    /** Not one of the host's accepted media types, or bytes that do not decode as the declared one. */
+    UNSUPPORTED_TYPE,
+
+    /** Over `maxImageBytes` on its own. */
+    TOO_LARGE,
+
+    /** Width times height is over `maxImagePixels`. */
+    TOO_MANY_PIXELS,
+
+    /** One side is over `maxImageDimension`. */
+    DIMENSION_TOO_LARGE,
+
+    /** Over `maxImagesPerMessage` images in the one message. */
+    TOO_MANY,
+
+    /** The message's images total more than `maxMessageImageBytes`. */
+    BATCH_TOO_LARGE,
+
+    /** The session's model takes no images at all. */
+    MODEL_UNSUPPORTED,
+
+    /** A subagent transcript, which the harness does not accept images into. */
+    SUBAGENT_UNSUPPORTED,
+
+    /** A refusal this client has no copy for; the raw reason is shown instead. */
+    UNKNOWN,
+}
+
+/**
+ * Map an `attachment-error` `details.reason` onto the same vocabulary the pre-check uses.
+ * An unrecognised code is [ImageRejection.UNKNOWN] rather than a failure: the reason string is
+ * host-owned and may grow, and the caller falls back to showing it verbatim.
+ */
+fun imageRejectionOf(reason: String): ImageRejection = when (reason) {
+    "IMAGE_TOO_LARGE" -> ImageRejection.TOO_LARGE
+    "IMAGE_TOO_MANY_PIXELS" -> ImageRejection.TOO_MANY_PIXELS
+    "IMAGE_DIMENSION_TOO_LARGE" -> ImageRejection.DIMENSION_TOO_LARGE
+    "TOO_MANY_IMAGES" -> ImageRejection.TOO_MANY
+    "IMAGES_TOO_LARGE" -> ImageRejection.BATCH_TOO_LARGE
+    "UNSUPPORTED_IMAGE_TYPE", "INVALID_IMAGE", "IMAGE_TYPE_MISMATCH", "INVALID_IMAGE_BASE64" ->
+        ImageRejection.UNSUPPORTED_TYPE
+    "MODEL_DOES_NOT_SUPPORT_IMAGES" -> ImageRejection.MODEL_UNSUPPORTED
+    "SUBAGENT_IMAGE_UNSUPPORTED" -> ImageRejection.SUBAGENT_UNSUPPORTED
+    else -> ImageRejection.UNKNOWN
+}
+
+/**
  * The `imageLimits` projection: the host's own attachment bounds. Defaults mirror the shipped
  * harness so a client that never receives the projection still refuses obviously-oversized images.
+ *
+ * `maxImageDimension` arrived in harness 0.1.0-rc.8, which also lowered the shipped
+ * `maxImageBytes` from 5MB to 3.5MB. Both defaults track the harness rather than this client:
+ * an rc.7 host sends no dimension and the default stands in, which is the same bound the
+ * deployed model routes apply anyway.
  */
 @Serializable
 data class ImageLimitsView(
-    @SerialName("maxImageBytes") val maxImageBytes: Long = 5_242_880,
+    @SerialName("maxImageBytes") val maxImageBytes: Long = 3_670_016,
     @SerialName("maxImagesPerMessage") val maxImagesPerMessage: Int = 20,
     @SerialName("maxMessageImageBytes") val maxMessageImageBytes: Long = 104_857_600,
     @SerialName("maxImagePixels") val maxImagePixels: Long = 40_000_000,
+    @SerialName("maxImageDimension") val maxImageDimension: Int = 2_000,
     @SerialName("mediaTypes") val mediaTypes: List<String> =
         listOf("image/png", "image/jpeg", "image/webp", "image/gif"),
 ) {
-    /** True when the host would accept an attachment of this media type and size. */
-    fun accepts(mediaType: String, bytes: Int): Boolean =
-        mediaType in mediaTypes && bytes <= maxImageBytes
+    /**
+     * Why adding one more image would break the *message's* bounds, or null when it would not.
+     *
+     * Run before [admitImage], because that is the order `AttachmentStore.saveImages` uses: it
+     * refuses the batch on count and then on aggregate size before it looks at any single member.
+     * Matching the order matters — a refusal raised here has to name the same limit the host
+     * would have named, or the message the user reads changes depending on who said no.
+     *
+     * @param pendingCount images already attached to this message, excluding the new one.
+     * @param pendingBytes their total encoded size.
+     * @param addedBytes the new image's encoded size.
+     */
+    fun admitBatch(pendingCount: Int, pendingBytes: Long, addedBytes: Int): ImageRejection? = when {
+        pendingCount + 1 > maxImagesPerMessage -> ImageRejection.TOO_MANY
+        pendingBytes + addedBytes > maxMessageImageBytes -> ImageRejection.BATCH_TOO_LARGE
+        else -> null
+    }
+
+    /**
+     * Why the host would refuse this one image, or null when it would take it.
+     *
+     * The sequence is the host's own — declared type, encoded size, decodability, then the two
+     * decoded-size bounds, then the declared type against the bytes. `maxImagePixels` is checked
+     * before `maxImageDimension` because `detectImage` checks them in that order, so an image
+     * that breaks both is reported as a resolution problem on both sides.
+     *
+     * @param detectedMediaType what the bytes themselves decode as, or null when they did not
+     *   decode at all; a mismatch against [declaredMediaType] is the host's `IMAGE_TYPE_MISMATCH`.
+     */
+    fun admitImage(
+        declaredMediaType: String,
+        detectedMediaType: String?,
+        bytes: Int,
+        width: Int,
+        height: Int,
+    ): ImageRejection? = when {
+        declaredMediaType !in mediaTypes -> ImageRejection.UNSUPPORTED_TYPE
+        bytes > maxImageBytes -> ImageRejection.TOO_LARGE
+        bytes <= 0 || width <= 0 || height <= 0 -> ImageRejection.UNSUPPORTED_TYPE
+        width.toLong() * height.toLong() > maxImagePixels -> ImageRejection.TOO_MANY_PIXELS
+        maxOf(width, height) > maxImageDimension -> ImageRejection.DIMENSION_TOO_LARGE
+        detectedMediaType != null && detectedMediaType != declaredMediaType ->
+            ImageRejection.UNSUPPORTED_TYPE
+        else -> null
+    }
 }
 
 /** The `plan` projection: whether plan mode is on, and whether a plan is awaiting review. */

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SessionsDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SessionsDtos.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.json.JsonElement
 
 /**
  * Sessions-domain DTOs, ported from `packages/host/apiproxy/src/api/sessions.schema.ts` and
- * `packages/host/apiproxy/src/api/sessions.ts` (v0.1.0-rc.7). Includes the request/response
+ * `packages/host/apiproxy/src/api/sessions.ts` (v0.1.0-rc.8). Includes the request/response
  * values of every `session.*` method (list/search/create/rename/fork/history/models/selectModel/
  * prompt/attachment/updateQueue/cancel) plus the shared model-catalog and attachment shapes.
  */

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SettingsDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SettingsDtos.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.json.JsonElement
 
 /**
  * Settings-domain DTOs, ported from `packages/host/apiproxy/src/api/settings.schema.ts` and
- * `packages/host/apiproxy/src/api/settings.ts` (v0.1.0-rc.7).
+ * `packages/host/apiproxy/src/api/settings.ts` (v0.1.0-rc.8).
  */
 
 /** One redacted secret slot. */

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SkillsDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SkillsDtos.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Skills-domain DTOs, ported from `packages/host/apiproxy/src/api/skills.schema.ts` and
- * `packages/host/apiproxy/src/api/skills.ts` (v0.1.0-rc.7). Listing is the domain's only RPC:
+ * `packages/host/apiproxy/src/api/skills.ts` (v0.1.0-rc.8). Listing is the domain's only RPC:
  * invocation itself is a plain `session.prompt` whose leading `/name` token the host recognizes.
  */
 

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SubagentDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SubagentDtos.kt
@@ -26,7 +26,7 @@ import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Subagents-domain DTOs, ported from `packages/host/apiproxy/src/api/subagents.schema.ts` and
- * `packages/host/apiproxy/src/api/subagents.ts` (v0.1.0-rc.7).
+ * `packages/host/apiproxy/src/api/subagents.ts` (v0.1.0-rc.8).
  */
 
 /**

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/WorkspaceDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/WorkspaceDtos.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Workspace-domain DTOs, ported from `packages/host/apiproxy/src/api/workspace.schema.ts` and
- * `packages/host/apiproxy/src/api/workspace.ts` (v0.1.0-rc.7).
+ * `packages/host/apiproxy/src/api/workspace.ts` (v0.1.0-rc.8).
  */
 
 /** One workspace row: the record projection every workspace.* value carries. */

--- a/core/src/test/kotlin/com/labteto/dshmobile/core/session/EventFoldTest.kt
+++ b/core/src/test/kotlin/com/labteto/dshmobile/core/session/EventFoldTest.kt
@@ -85,6 +85,64 @@ class EventFoldTest {
     }
 
     @Test
+    fun interruptedMarkerOnTheMessageIsHonoured() {
+        // Harness 0.1.0-rc.8 finalises a cancelled turn's delivered prefix as a real message and
+        // marks it, so the text survives and the badge is right before the turn has even ended.
+        val events = listOf(
+            event("turn/start", 0, buildJsonObject { put("turn", 2) }),
+            event("assistant/message", 1, buildJsonObject {
+                put("turn", 2); put("step", 1); put("interrupted", true)
+                putJsonObject("message") {
+                    put("id", "a2")
+                    putJsonArray("content") {
+                        add(buildJsonObject { put("type", "text"); put("text", "as far as I got") })
+                    }
+                }
+            }),
+        )
+        val snapshot = EventFold("s1").fold(events)
+        val assistant = snapshot.nodes.first { it is AssistantMessageNode } as AssistantMessageNode
+        assertTrue(assistant.interrupted)
+        assertEquals("as far as I got", assistant.plainText)
+    }
+
+    @Test
+    fun theMarkedMessageIsNotRemarkedByTheTurnEnding() {
+        // Both sources agree here; the point is that the fallback stands aside rather than
+        // walking the turn again and possibly landing on a different, complete message.
+        val events = listOf(
+            event("turn/start", 0, buildJsonObject { put("turn", 3) }),
+            event("assistant/message", 1, buildJsonObject {
+                put("turn", 3); put("step", 1)
+                putJsonObject("message") {
+                    put("id", "done")
+                    putJsonArray("content") {
+                        add(buildJsonObject { put("type", "text"); put("text", "first step") })
+                    }
+                }
+            }),
+            event("assistant/message", 2, buildJsonObject {
+                put("turn", 3); put("step", 2); put("interrupted", true)
+                putJsonObject("message") {
+                    put("id", "cut")
+                    putJsonArray("content") {
+                        add(buildJsonObject { put("type", "text"); put("text", "second step, cut") })
+                    }
+                }
+            }),
+            event("turn/end", 3, buildJsonObject {
+                put("turn", 3)
+                putJsonObject("reason") { put("kind", "interrupted") }
+            }),
+        )
+        val snapshot = EventFold("s1").fold(events)
+        val assistants = snapshot.nodes.filterIsInstance<AssistantMessageNode>()
+        assertEquals(2, assistants.size)
+        assertFalse(assistants.first().interrupted)
+        assertTrue(assistants.last().interrupted)
+    }
+
+    @Test
     fun unknownEventBecomesOtherNode() {
         val events = listOf(
             event("mystery/event", 0, buildJsonObject { put("x", 1) }),

--- a/core/src/test/kotlin/com/labteto/dshmobile/core/wire/ConnectionLoopHandshakeTest.kt
+++ b/core/src/test/kotlin/com/labteto/dshmobile/core/wire/ConnectionLoopHandshakeTest.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.InputStream
@@ -57,6 +59,14 @@ class ConnectionLoopHandshakeTest {
     }
 
     private fun describeOk() = RpcHttpResponse(
+        200,
+        """{"type":"server-response","rpcId":"r","result":{"ok":true,"value":""" +
+            """{"version":"0.1.0-rc.8","cwd":"/tmp","attachedSessions":0,"home":"/home/demo",""" +
+            """"canOpenPath":false}}}""",
+    )
+
+    /** A pre-0.1.0-rc.8 host: the same value with the field that release made required removed. */
+    private fun describeRc7() = RpcHttpResponse(
         200,
         """{"type":"server-response","rpcId":"r","result":{"ok":true,"value":""" +
             """{"version":"0.1.0-rc.7","cwd":"/tmp","attachedSessions":0,"canOpenPath":false}}}""",
@@ -156,7 +166,39 @@ class ConnectionLoopHandshakeTest {
         loop.stop()
 
         assertEquals(listOf(HandshakeStep.OPENING_STREAMS, HandshakeStep.DESCRIBING), recorder.steps.take(2))
-        assertEquals("0.1.0-rc.7", recorder.connected.first().version)
+        assertEquals("0.1.0-rc.8", recorder.connected.first().version)
+        assertEquals("/home/demo", recorder.connected.first().home)
         assertTrue(recorder.failures.isEmpty())
+    }
+
+    @Test
+    fun `a host predating the home field still connects`() = runBlocking {
+        // `home` became required in 0.1.0-rc.8. Declaring it non-null on this side would have
+        // turned every older harness into "not a harness" at the one step that decides whether
+        // the app connects at all, so its absence has to stay a fact rather than a failure.
+        val recorder = Recorder()
+        val loop = loop(recorder, open = { it.onOpen() }, describe = ::describeRc7)
+        loop.start()
+        assertTrue(await { recorder.connected.isNotEmpty() })
+        loop.stop()
+
+        assertEquals("0.1.0-rc.7", recorder.connected.first().version)
+        assertNull(recorder.connected.first().home)
+        assertTrue(recorder.failures.isEmpty())
+    }
+
+    @Test
+    fun `the describe answer decides which command shape this connection sends`() = runBlocking {
+        // The one place the client has to choose what to *send* rather than what to ignore:
+        // `commands/execute` gained a required `images` argument in 0.1.0-rc.8 and the gateway
+        // refuses an args object that does not match its descriptor in either direction.
+        val rc8 = DshApiClient(StubTransport(::describeOk)) { _, sink -> FakeWs(sink) { } }
+        assertFalse("undecided until the host answers", rc8.acceptsCommandImages)
+        assertTrue(rc8.hostDescribe() is RpcResult.Ok)
+        assertTrue(rc8.acceptsCommandImages)
+
+        val rc7 = DshApiClient(StubTransport(::describeRc7)) { _, sink -> FakeWs(sink) { } }
+        assertTrue(rc7.hostDescribe() is RpcResult.Ok)
+        assertFalse(rc7.acceptsCommandImages)
     }
 }

--- a/core/src/test/kotlin/com/labteto/dshmobile/core/wire/DshApiClientRemoteTest.kt
+++ b/core/src/test/kotlin/com/labteto/dshmobile/core/wire/DshApiClientRemoteTest.kt
@@ -3,10 +3,13 @@ package com.labteto.dshmobile.core.wire
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import kotlinx.coroutines.test.runTest
+import com.labteto.dshmobile.core.wire.dto.EncodedImageAttachment
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -56,7 +59,11 @@ class DshApiClientRemoteTest {
     fun `commands list posts a client-request envelope with agentId in args`() = runTest {
         val transport = RecordingTransport { _, body ->
             val rpcId = Json.parseToJsonElement(body).jsonObject["rpcId"]!!.jsonPrimitive.content
-            ok(rpcId, """[{"name":"permission","description":"Switch","input":{"hint":"<preset>"}}]""")
+            ok(
+                rpcId,
+                """[{"name":"permission","description":"Switch","input":{"hint":"<preset>"}},""" +
+                    """{"name":"goal","description":"Set","input":{"hint":"<objective>","images":true}}]""",
+            )
         }
         val result = client(transport).commandsList("session-1")
 
@@ -73,24 +80,100 @@ class DshApiClientRemoteTest {
         assertEquals("session-1", args["agentId"]!!.jsonPrimitive.content)
 
         val commands = (result as RpcResult.Ok).value
-        assertEquals(1, commands.size)
+        assertEquals(2, commands.size)
         assertEquals("permission", commands.first().name)
         assertEquals("<preset>", commands.first().input?.hint)
+        // `input.images` arrived in 0.1.0-rc.8 and is only ever sent as true, so a descriptor
+        // without the key is a command that takes none — which is every command before rc.8.
+        assertFalse(commands.first().acceptsImages)
+        assertTrue(commands.last().acceptsImages)
+    }
+
+    /**
+     * A `host.describe` answer, which is also what decides this connection's `commands/execute`
+     * argument shape. Pass `home = null` for a harness older than 0.1.0-rc.8.
+     */
+    private fun describeBody(rpcId: String, home: String?) = ok(
+        rpcId,
+        """{"version":"v","cwd":"/w","attachedSessions":0,""" +
+            (if (home == null) "" else """"home":"$home",""") +
+            """"canOpenPath":true}""",
+    )
+
+    /** A client that has already described the host, so its command shape is decided. */
+    private suspend fun describedClient(transport: RecordingTransport): DshApiClient {
+        val api = client(transport)
+        assertTrue(api.hostDescribe() is RpcResult.Ok)
+        return api
     }
 
     @Test
-    fun `commands execute sends agentId and line`() = runTest {
-        val transport = RecordingTransport { _, body ->
+    fun `a pre-rc8 host is sent the two-argument command shape it declares`() = runTest {
+        val transport = RecordingTransport { path, body ->
             val rpcId = Json.parseToJsonElement(body).jsonObject["rpcId"]!!.jsonPrimitive.content
-            ok(rpcId, "{}")
+            if (path.endsWith("host.describe")) describeBody(rpcId, null) else ok(rpcId, "{}")
         }
-        client(transport).commandsExecute("session-2", "/permission workspace-write")
+        describedClient(transport).commandsExecute("session-2", "/permission workspace-write")
 
         val args = Json.parseToJsonElement(transport.lastBody!!)
             .jsonObject["payload"]!!.jsonObject["args"]!!.jsonObject
+        // `images` is not merely unnecessary here — the gateway refuses an argument its descriptor
+        // does not declare, so sending it would fail every slash command against this harness.
         assertEquals(setOf("agentId", "line"), args.keys)
         assertEquals("session-2", args["agentId"]!!.jsonPrimitive.content)
         assertEquals("/permission workspace-write", args["line"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `an rc8 host is sent images even when there are none`() = runTest {
+        val transport = RecordingTransport { path, body ->
+            val rpcId = Json.parseToJsonElement(body).jsonObject["rpcId"]!!.jsonPrimitive.content
+            if (path.endsWith("host.describe")) describeBody(rpcId, "/home/demo") else ok(rpcId, "{}")
+        }
+        describedClient(transport).commandsExecute("session-2", "/compact")
+
+        val args = Json.parseToJsonElement(transport.lastBody!!)
+            .jsonObject["payload"]!!.jsonObject["args"]!!.jsonObject
+        // Required from 0.1.0-rc.8: omitting it is refused exactly as an unexpected key would be.
+        assertEquals(setOf("agentId", "line", "images"), args.keys)
+        assertEquals(0, args["images"]!!.jsonArray.size)
+    }
+
+    @Test
+    fun `an rc8 host carries the composer's images on the command`() = runTest {
+        val transport = RecordingTransport { path, body ->
+            val rpcId = Json.parseToJsonElement(body).jsonObject["rpcId"]!!.jsonPrimitive.content
+            if (path.endsWith("host.describe")) describeBody(rpcId, "/home/demo") else ok(rpcId, "{}")
+        }
+        describedClient(transport).commandsExecute(
+            "session-2",
+            "/goal ship it",
+            listOf(EncodedImageAttachment("image/png", "AAAA")),
+        )
+
+        val args = Json.parseToJsonElement(transport.lastBody!!)
+            .jsonObject["payload"]!!.jsonObject["args"]!!.jsonObject
+        val image = args["images"]!!.jsonArray.single().jsonObject
+        assertEquals("image/png", image["mediaType"]!!.jsonPrimitive.content)
+        assertEquals("AAAA", image["data"]!!.jsonPrimitive.content)
+        // explicitNulls = false: an absent display name is an absent key, not a null one.
+        assertEquals(setOf("mediaType", "data"), image.keys)
+    }
+
+    @Test
+    fun `images sent to a host that cannot carry them are refused, not dropped`() = runTest {
+        val transport = RecordingTransport { path, body ->
+            val rpcId = Json.parseToJsonElement(body).jsonObject["rpcId"]!!.jsonPrimitive.content
+            if (path.endsWith("host.describe")) describeBody(rpcId, null) else ok(rpcId, "{}")
+        }
+        val result = describedClient(transport).commandsExecute(
+            "session-2",
+            "/goal ship it",
+            listOf(EncodedImageAttachment("image/png", "AAAA")),
+        )
+
+        // Running the command without the pictures the user attached to it would look like success.
+        assertEquals("capability-unavailable", (result as RpcResult.Err).error.code)
     }
 
     @Test

--- a/core/src/test/kotlin/com/labteto/dshmobile/core/wire/dto/ProjectionDtosTest.kt
+++ b/core/src/test/kotlin/com/labteto/dshmobile/core/wire/dto/ProjectionDtosTest.kt
@@ -66,10 +66,74 @@ class ProjectionDtosTest {
     @Test
     fun `image limits default to the shipped harness bounds when absent`() {
         val limits = decodeFromString<ImageLimitsView>("{}")
-        assertEquals(5_242_880L, limits.maxImageBytes)
-        assertTrue(limits.accepts("image/png", 1_000))
-        assertTrue(!limits.accepts("image/tiff", 1_000))
-        assertTrue(!limits.accepts("image/png", 6_000_000))
+        // 0.1.0-rc.8 lowered the per-image cap from 5MB and added the per-side one.
+        assertEquals(3_670_016L, limits.maxImageBytes)
+        assertEquals(2_000, limits.maxImageDimension)
+        assertNull(limits.admitImage("image/png", "image/png", 1_000, 100, 100))
+    }
+
+    @Test
+    fun `an image is refused for the reason the host would have given`() {
+        val limits = decodeFromString<ImageLimitsView>("{}")
+        assertEquals(
+            ImageRejection.UNSUPPORTED_TYPE,
+            limits.admitImage("image/tiff", "image/tiff", 1_000, 100, 100),
+        )
+        assertEquals(
+            ImageRejection.TOO_LARGE,
+            limits.admitImage("image/png", "image/png", 4_000_000, 100, 100),
+        )
+        assertEquals(
+            ImageRejection.DIMENSION_TOO_LARGE,
+            limits.admitImage("image/png", "image/png", 1_000, 2_400, 100),
+        )
+        // Bytes that did not decode read as a format problem, which is the host's answer too.
+        assertEquals(
+            ImageRejection.UNSUPPORTED_TYPE,
+            limits.admitImage("image/png", null, 1_000, 0, 0),
+        )
+        // A file whose bytes contradict the type its provider declared.
+        assertEquals(
+            ImageRejection.UNSUPPORTED_TYPE,
+            limits.admitImage("image/png", "image/jpeg", 1_000, 100, 100),
+        )
+    }
+
+    @Test
+    fun `an oversized image reports resolution before per-side, as the host checks it`() {
+        // detectImage tests maxPixels first, so an image that breaks both bounds has to be
+        // reported as a resolution problem here as well or the two sides disagree.
+        val limits = decodeFromString<ImageLimitsView>("""{"maxImagePixels":10000}""")
+        assertEquals(
+            ImageRejection.TOO_MANY_PIXELS,
+            limits.admitImage("image/png", "image/png", 1_000, 9_000, 9_000),
+        )
+    }
+
+    @Test
+    fun `the message's own bounds are checked before any single image`() {
+        val limits = decodeFromString<ImageLimitsView>("""{"maxImagesPerMessage":2}""")
+        assertNull(limits.admitBatch(pendingCount = 1, pendingBytes = 10, addedBytes = 10))
+        assertEquals(
+            ImageRejection.TOO_MANY,
+            limits.admitBatch(pendingCount = 2, pendingBytes = 10, addedBytes = 10),
+        )
+        val byBytes = decodeFromString<ImageLimitsView>("""{"maxMessageImageBytes":100}""")
+        assertEquals(
+            ImageRejection.BATCH_TOO_LARGE,
+            byBytes.admitBatch(pendingCount = 1, pendingBytes = 60, addedBytes = 50),
+        )
+    }
+
+    @Test
+    fun `a host refusal maps onto the same vocabulary as the pre-check`() {
+        assertEquals(ImageRejection.DIMENSION_TOO_LARGE, imageRejectionOf("IMAGE_DIMENSION_TOO_LARGE"))
+        assertEquals(ImageRejection.TOO_MANY, imageRejectionOf("TOO_MANY_IMAGES"))
+        assertEquals(ImageRejection.BATCH_TOO_LARGE, imageRejectionOf("IMAGES_TOO_LARGE"))
+        assertEquals(ImageRejection.UNSUPPORTED_TYPE, imageRejectionOf("UNSUPPORTED_IMAGE_TYPE"))
+        assertEquals(ImageRejection.MODEL_UNSUPPORTED, imageRejectionOf("MODEL_DOES_NOT_SUPPORT_IMAGES"))
+        // A reason this build has never heard of stays reportable rather than becoming a crash.
+        assertEquals(ImageRejection.UNKNOWN, imageRejectionOf("SOMETHING_THE_HARNESS_ADDED_LATER"))
     }
 
     @Test

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -80,4 +80,4 @@ tools/capture/  Node recorder of real harness traffic → conformance fixtures
 - Settings/credentials/host-native methods are loopback-only by harness
   design; over LAN the app surfaces them read-only (see
   `docs/COMPATIBILITY.md`).
-- Protocol baseline: harness `0.1.0-rc.7` (`core.DshCore.PROTOCOL_BASELINE`).
+- Protocol baseline: harness `0.1.0-rc.8` (`core.DshCore.PROTOCOL_BASELINE`).

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -8,8 +8,9 @@ checked against.
 
 | DSH Mobile | Harness version | Status |
 |---|---|---|
-| 0.4.0 | 0.1.0-rc.7 | Supported baseline |
-| 0.1.0 – 0.3.1 | 0.1.0-rc.5 | Previous baseline |
+| 0.5.0 | 0.1.0-rc.8 | Supported baseline |
+| 0.4.0 | 0.1.0-rc.7 | Previous baseline |
+| 0.1.0 – 0.3.1 | 0.1.0-rc.5 | |
 
 The baseline is one constant — `DshCore.PROTOCOL_BASELINE` in
 `core/src/main/kotlin/com/labteto/dshmobile/core/DshCore.kt` — and the app shows
@@ -19,11 +20,13 @@ it in Settings → About next to its own version.
 
 The baseline says what was tested. It is not a gate, and the app does not compare
 it against `host.describe.version` or warn when the two differ — it could not say
-what would break if it did. The harness releases far more often than this client,
-and most of those releases leave the client surface untouched: rc.5 → rc.7 added
-no RPC method, no event type, no projection key and no slash command. A banner
-firing on every harness that is not one exact string would be noise on every
-session, and would still be silent about the changes that actually matter.
+what would break if it did. The harness releases far more often than this client.
+Some of those releases leave the client surface untouched — rc.5 → rc.7 added no
+RPC method, no event type, no projection key and no slash command — and some do
+not: rc.7 → rc.8 added a required field to `host.describe`, a required key to the
+`imageLimits` projection, and a required third argument to `commands/execute`. A
+banner firing on every harness that is not one exact string would be noise on
+every session, and would still be silent about which of those two a release was.
 
 What the app does instead:
 
@@ -32,11 +35,30 @@ What the app does instead:
   unknown keys are ignored. A build that composes no such capability answers 404
   or 403, which the client reads as "this build does not offer that" and hides
   the control instead of reporting a failure.
+- **Reads capability off the wire when it has to choose what to _send_.** rc.8
+  gave `commands/execute` a required `images` argument, and the harness gateway
+  matches an args object against its descriptor exactly — it refuses a missing
+  key as readily as an unexpected one, so "ignore what you do not understand" has
+  nothing to offer here. The client decides from a field only rc.8 emits
+  (`host.describe.home`) rather than from a version comparison, so a fork, a
+  pre-release or a downstream build is judged on what it actually sends. This is
+  the one such branch in the client, and it exists because that gateway leaves no
+  third option — not because host-shape branching is a pattern to reach for.
 - **Shows the harness's own version** wherever a host appears — the connect list,
   the details panel, and Settings → Harness — so a mismatch is visible where it
   is useful rather than announced as an alarm.
 - **Re-checks on each harness release** with the fixture capture tool
   (`tools/capture`), and moves the baseline once the shapes have been verified.
+
+## Known differences by harness release
+
+- **Slash commands with images need rc.8.** `/goal` and `/plan` accept composer
+  attachments there; every other command refuses them, and against an rc.7 host
+  so does this client, because that release has no wire slot to carry them.
+- **Image bounds are the host's.** rc.8 lowered the shipped per-image cap from
+  5MB to 3.5MB and added a 2000px per-side cap. The app enforces whatever the
+  `imageLimits` projection says and falls back to rc.8's defaults when a host
+  publishes none, which can refuse a 4MB image an rc.7 host would have taken.
 
 ## Loopback-only surfaces (by harness design)
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -42,15 +42,36 @@ both mean "this build does not offer that", not "the connection is broken", so
 the client maps them to `capability-unavailable` / `forbidden` and hides the
 feature instead of reporting a failure.
 
-`commands/execute` (`{"args":{"agentId","line"}}`) is the **only** command write
-path. `session.prompt` does not inspect its content — a leading-slash prompt
-reaches the model as ordinary user text — so the client adjudicates the draft
-against `commands/list` before sending and only calls `session.prompt` when the
-line names no registered command. That miss is load-bearing: a `/name` line the
-catalog does not claim is how a *skill* is invoked, and the host's pre-step
-boundary resolves it. The remote answers with no `value` when the line parses to
-no command; since the codec folds an absent value into `{}`, the discriminator is
-the presence of `commandId`.
+`commands/execute` is the **only** command write path. `session.prompt` does not
+inspect its content — a leading-slash prompt reaches the model as ordinary user
+text — so the client adjudicates the draft against `commands/list` before sending
+and only calls `session.prompt` when the line names no registered command. That
+miss is load-bearing: a `/name` line the catalog does not claim is how a *skill*
+is invoked, and the host's pre-step boundary resolves it. The remote answers with
+no `value` when the line parses to no command; since the codec folds an absent
+value into `{}`, the discriminator is the presence of `commandId`.
+
+Its argument shape depends on the harness release, and this is the one call where
+that matters:
+
+```json
+{"args":{"agentId","line"}}                       // 0.1.0-rc.7 and earlier
+{"args":{"agentId","line","images":[…]}}          // 0.1.0-rc.8 and later
+```
+
+`images` is a required argument from rc.8, carrying `{mediaType, data, name?}`
+per member with `data` as canonical base64 — and the gateway refuses an args
+object that does not match its descriptor, a missing key as readily as an
+unexpected one. So the shape has to be chosen rather than written once. The
+client chooses on the presence of `host.describe.home`, a field rc.8 made
+required and rc.7 never sent, latched for the connection during the handshake.
+
+A non-empty batch is only accepted by a command whose `commands/list` descriptor
+declares `input.images` — `/goal` and `/plan` at rc.8, nothing else. The executor
+enforces that, not the composer, but the client refuses first so the draft and
+the pictures survive a refusal. Sub-command grammar stays with the host: `/plan
+off` and `/goal pause` answer with an ordinary error result rather than being
+adjudicated here.
 
 The `command` slot on `session.prompt`'s response, and the `unknown-command` /
 `command-error` codes, are dead schema the host never populates.
@@ -135,7 +156,7 @@ Several facts the UI needs never arrive as an RPC result — they are pushed as
 | `sessionStats` | `{turns, steps, llmMs, toolMs, ttftMs, ttftSteps, decodeMs, decodeTokens}` — `ttftMs` is a **sum** over `ttftSteps`, and throughput must be derived from `decodeTokens / decodeMs` |
 | `tokenUsage` | `{uncachedInputTokens, outputTokens, cacheReadTokens, cacheWriteTokens}` |
 | `contextPressure` / `contextBreakdown` | context-window occupancy, and what fills it |
-| `imageLimits` | the host's own attachment bounds |
+| `imageLimits` | `{maxImageBytes, maxImagesPerMessage, maxMessageImageBytes, maxImagePixels, maxImageDimension, mediaTypes}` — the host's own attachment bounds, all of them enforced before upload; `maxImageDimension` is a per-side cap added in harness 0.1.0-rc.8 |
 | `goal`, `todos`, `plan`, `title`, `sessionListMetadata` | the docks and list metadata |
 
 An absent key means the harness composes no such service; clients hide the

--- a/mock-harness/src/main/kotlin/com/labteto/dshmobile/mockharness/MockHarness.kt
+++ b/mock-harness/src/main/kotlin/com/labteto/dshmobile/mockharness/MockHarness.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -159,9 +160,58 @@ class MockHarness(
     /**
      * Overrides the built-in `host.describe` handler: [transform] receives the default
      * describe value and returns the value that will be served.
+     *
+     * Use it to serve a pre-0.1.0-rc.8 host by dropping the key that release added:
+     * `describe { JsonObject(it - "home") }`.
      */
     fun describe(transform: (JsonObject) -> JsonObject) {
         describeTransform = transform
+    }
+
+    /**
+     * Registers a typert remote under `namespace/method`, held to the gateway's own argument rule.
+     *
+     * The real gateway matches an args object against the remote's declared parameters and refuses
+     * it for a missing key as readily as for an unexpected one — which is why a client cannot write
+     * one `commands/execute` payload for every harness release. A mock that accepted whatever
+     * arrived would be exactly blind to the mistake worth catching, so this one answers the
+     * gateway's own error instead.
+     *
+     * @param expectedArgs the descriptor's complete argument key set.
+     * @param handler maps the validated args object to the remote's return value.
+     */
+    fun remote(
+        namespace: String,
+        method: String,
+        expectedArgs: Set<String>,
+        handler: (JsonObject) -> JsonElement,
+    ) {
+        val endpoint = "$namespace/$method"
+        okHandlers.remove(endpoint)
+        asyncHandlers.remove(endpoint)
+        failHandlers.remove(endpoint)
+        okHandlers[endpoint] = { payload ->
+            val args = (payload as? JsonObject)?.get("args") as? JsonObject
+                ?: throw IllegalArgumentException("args must be a plain object")
+            val missing = expectedArgs.filterNot { it in args.keys }
+            val unexpected = args.keys.filterNot { it in expectedArgs }
+            if (missing.isEmpty() && unexpected.isEmpty()) {
+                handler(args)
+            } else {
+                throw ArgumentsInvalid(argumentsInvalidMessage(missing, unexpected))
+            }
+        }
+    }
+
+    /** The gateway's `arguments-invalid` refusal, thrown out of a [remote] handler. */
+    class ArgumentsInvalid(override val message: String) : RuntimeException(message)
+
+    private fun argumentsInvalidMessage(missing: List<String>, unexpected: List<String>): String {
+        val clauses = buildList {
+            if (missing.isNotEmpty()) add("missing " + missing.joinToString(", ") { "\"$it\"" })
+            if (unexpected.isNotEmpty()) add("unexpected " + unexpected.joinToString(", ") { "\"$it\"" })
+        }
+        return "args fields do not match the descriptor: " + clauses.joinToString("; ")
     }
 
     /**
@@ -253,8 +303,14 @@ class MockHarness(
         when {
             asyncHandlers.containsKey(method) ->
                 respondJson(okEnvelope(rpcId, asyncHandlers[method]!!(payload)))
-            okHandlers.containsKey(method) ->
+            okHandlers.containsKey(method) -> try {
                 respondJson(okEnvelope(rpcId, okHandlers[method]!!(payload)))
+            } catch (invalid: ArgumentsInvalid) {
+                // The gateway reports a refused args object as an ordinary thrown failure, which
+                // the RPC layer renders with code `internal` — a shape mismatch does not get its
+                // own error code, which is exactly why the client must not send one to find out.
+                respondJson(errorEnvelope(rpcId, "internal", invalid.message))
+            }
             failHandlers.containsKey(method) -> {
                 val error = failHandlers[method]!!(payload)
                 respondJson(errorEnvelope(rpcId, error.code, error.message, error.details))
@@ -313,13 +369,50 @@ class MockHarness(
 
     private fun describeValue(): JsonObject {
         val base = buildJsonObject {
-            put("version", "0.1.0-rc.7")
+            put("version", "0.1.0-rc.8")
             put("cwd", "C:\\demo")
             put("attachedSessions", 0)
+            put("home", "C:\\Users\\demo")
             put("canOpenPath", true)
         }
         return describeTransform?.invoke(base) ?: base
     }
+
+    /**
+     * The host's own attachment bounds, as the `imageLimits` session projection carries them.
+     *
+     * Values are the shipped harness defaults at 0.1.0-rc.8, including the 3.5MB per-image cap
+     * that release lowered from 5MB and the per-side `maxImageDimension` it added.
+     */
+    fun imageLimitsValue(): JsonObject = buildJsonObject {
+        put("maxImageBytes", 3_670_016)
+        put("maxImagesPerMessage", 20)
+        put("maxMessageImageBytes", 104_857_600)
+        put("maxImagePixels", 40_000_000)
+        put("maxImageDimension", 2_000)
+        putJsonArray("mediaTypes") {
+            add("image/png")
+            add("image/jpeg")
+            add("image/webp")
+            add("image/gif")
+        }
+    }
+
+    /** Broadcast one `session/projection` frame, the way the host publishes a projection value. */
+    suspend fun pushProjection(
+        sessionId: String,
+        key: String,
+        value: JsonElement,
+        seq: Int = 0,
+    ): String = pushMux(
+        buildJsonObject {
+            put("type", "session/projection")
+            put("sessionId", sessionId)
+            put("key", key)
+            put("value", value)
+            put("seq", seq)
+        },
+    )
 
     /**
      * A small but representative plugin inventory.

--- a/mock-harness/src/test/kotlin/com/labteto/dshmobile/mockharness/MockHarnessTest.kt
+++ b/mock-harness/src/test/kotlin/com/labteto/dshmobile/mockharness/MockHarnessTest.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.BeforeClass
 import org.junit.Test
@@ -58,10 +59,62 @@ class MockHarnessTest {
         val result = body["result"]!!.jsonObject
         assertTrue(result["ok"]!!.jsonPrimitive.boolean)
         val value = result["value"]!!.jsonObject
-        assertEquals("0.1.0-rc.7", value["version"]!!.jsonPrimitive.content)
+        assertEquals("0.1.0-rc.8", value["version"]!!.jsonPrimitive.content)
         assertEquals("C:\\demo", value["cwd"]!!.jsonPrimitive.content)
         assertEquals(0, value["attachedSessions"]!!.jsonPrimitive.int)
+        // Required from 0.1.0-rc.8, and the field the client reads to decide which
+        // `commands/execute` shape this host accepts.
+        assertEquals("C:\\Users\\demo", value["home"]!!.jsonPrimitive.content)
         assertTrue(value["canOpenPath"]!!.jsonPrimitive.boolean)
+    }
+
+    @Test
+    fun aRemoteHeldToItsDescriptorRefusesTheWrongArgumentShape() {
+        // The gateway refuses an args object that does not match its descriptor, for a missing key
+        // as readily as an unexpected one. That is the whole reason `commands/execute` cannot be
+        // written once for every harness release, so the mock has to say no the same way.
+        harness.remote("commands", "execute", setOf("agentId", "line", "images")) {
+            Json.parseToJsonElement("""{"commandId":"c1"}""")
+        }
+
+        val accepted = post(
+            "/api/commands/execute",
+            envelope("commands/execute", """{"args":{"agentId":"s1","line":"/compact","images":[]}}"""),
+        )
+        val acceptedResult = Json.parseToJsonElement(accepted.body()).jsonObject["result"]!!.jsonObject
+        assertTrue(acceptedResult["ok"]!!.jsonPrimitive.boolean)
+
+        val refused = post(
+            "/api/commands/execute",
+            envelope("commands/execute", """{"args":{"agentId":"s1","line":"/compact"}}"""),
+        )
+        val refusedResult = Json.parseToJsonElement(refused.body()).jsonObject["result"]!!.jsonObject
+        assertFalse(refusedResult["ok"]!!.jsonPrimitive.boolean)
+        val error = refusedResult["error"]!!.jsonObject
+        assertEquals("internal", error["code"]!!.jsonPrimitive.content)
+        assertTrue(error["message"]!!.jsonPrimitive.content.contains("missing"))
+
+        val unexpected = post(
+            "/api/commands/execute",
+            envelope(
+                "commands/execute",
+                """{"args":{"agentId":"s1","line":"/compact","images":[],"mode":"queue"}}""",
+            ),
+        )
+        val unexpectedResult = Json.parseToJsonElement(unexpected.body()).jsonObject["result"]!!.jsonObject
+        assertFalse(unexpectedResult["ok"]!!.jsonPrimitive.boolean)
+        assertTrue(
+            unexpectedResult["error"]!!.jsonObject["message"]!!.jsonPrimitive.content
+                .contains("unexpected"),
+        )
+    }
+
+    @Test
+    fun theImageLimitsProjectionCarriesThePerSideBound() {
+        val limits = harness.imageLimitsValue()
+        // 0.1.0-rc.8 added the per-side cap and lowered the per-image byte cap to 3.5MB.
+        assertEquals(2_000, limits["maxImageDimension"]!!.jsonPrimitive.int)
+        assertEquals(3_670_016, limits["maxImageBytes"]!!.jsonPrimitive.int)
     }
 
     @Test

--- a/tools/capture/README.md
+++ b/tools/capture/README.md
@@ -44,6 +44,8 @@ DSH_URL=http://192.168.1.20:3080 DSH_SECONDS=10 node tools/capture/capture.mjs
    result, saves `capture-output/session.list.json`.
 3. If sessions exist, `POST /api/session.history` for the **first** session with
    `maxMessages: 200` — prints the result, saves `capture-output/session.history.json`.
+   Then `POST /api/commands/list` for the same session, saved as
+   `capture-output/commands.list.json`.
 4. Opens `ws://…/api/events.mux` and `ws://…/api/events.host` and logs every pushed
    frame as one NDJSON line for `DSH_SECONDS` seconds.
 
@@ -58,7 +60,8 @@ All files live under `capture-output/` (root of the repo; already in `.gitignore
 | ----------------------- | ------------------------------------------------------------------------------------------------- |
 | `host.describe.json`    | `{"request": <client-request envelope>, "response": <server-response envelope>}`                  |
 | `session.list.json`     | Same wrapper for the session list call.                                                           |
-| `session.history.json`  | Same wrapper for the first session's history (only written when sessions exist).                  |
+| `session.history.json`  | Same wrapper for the first session's history (only written when sessions exist). Its `projections` tail block is where `imageLimits` shows up. |
+| `commands.list.json`    | Same wrapper for the session's command catalog — the only live view of which commands declare `input.images`. |
 | `events.mux.ndjson`     | One line per pushed mux frame: `{"request": null, "response": <server-request frame>}`            |
 | `events.host.ndjson`    | One line per pushed host frame: `{"request": null, "response": <server-request frame>}`           |
 

--- a/tools/capture/capture.mjs
+++ b/tools/capture/capture.mjs
@@ -9,6 +9,7 @@
  *   host.describe.json    {"request": <client-request>, "response": <server-response>}
  *   session.list.json     same wrapper
  *   session.history.json  same wrapper (only when session.list returned sessions)
+ *   commands.list.json    same wrapper for the session's command catalog
  *   events.mux.ndjson     one {"request": null, "response": <server-request frame>} per line
  *   events.host.ndjson    same wrapper for the host channel
  *
@@ -141,6 +142,12 @@ async function main() {
       const history = await postJson('session.history', { sessionId, maxMessages: 200 });
       console.log(`session.history -> HTTP ${history.status} ${JSON.stringify(history.response)}`);
       await writeCaptured('session.history.json', history.request, history.response);
+
+      // 3b. The command catalog. It is the only way to see `input.images` against a live host,
+      // and it is a typert Remote rather than an ordinary method, so the args object is nested.
+      const commands = await postJson('commands/list', { args: { agentId: sessionId } });
+      console.log(`commands/list -> HTTP ${commands.status} ${JSON.stringify(commands.response)}`);
+      await writeCaptured('commands.list.json', commands.request, commands.response);
     }
   } else {
     console.log('session.list: no sessions, skipping session.history');


### PR DESCRIPTION
Moves the protocol baseline to harness **0.1.0-rc.8**. The last move, rc.5 → rc.7, touched nothing on the wire; this one is a migration.

## Why now

`commands/execute` gained a required third argument, `images`, and the harness gateway matches an args object against its descriptor *exactly* — it refuses a missing key as readily as an unexpected one. This client sent two arguments, so against an rc.8 harness `/compact`, `/plan`, the permission picker and the feedback buttons would each have failed, and — because an unrecognised error code is read as a broken link — each failure would also have raised the connection banner over a perfectly healthy session.

## Fixed

- **Every slash command against an rc.8 harness.** The client now sends the shape the host in front of it declares, choosing on the presence of `host.describe.home` — a field rc.8 made required and rc.7 never sent — rather than on a version string. Both releases keep working.
- **A stopped answer used to vanish.** Nothing was ever committed for a cancelled step, so text already on screen was discarded. rc.8 finalises that prefix as a real message and marks it; the fold reads the mark, and no longer labels the previous complete message of a multi-step turn as interrupted when it was the *next* step that was cut.
- **Attaching several images made several messages.** `session.prompt` takes a list of content parts and the host admits it as one batch; this client sent one call per image, so the host's per-message count and total-size limits could never fire at all.
- **`web_search` rows went blank.** rc.8 replaced the tool's single `query` with a `queries` array.

## Added

- `/goal` and `/plan` take image attachments.
- A command that cannot take them now says so, with the draft and the images both left in place — instead of silently demoting the line to a prompt and sending the literal text `/goal` to the model.
- All five image bounds are enforced before upload, including rc.8's new 2000px per-side cap. Three of the five were being received and ignored. A refusal names the limit it crossed, and so does one that still comes back from the harness — the same sentences serve both, across all eleven languages.

## What moved on the wire

| Change | Kind |
|---|---|
| `host.describe` → required `home` | breaking (parse) |
| `imageLimits` → required `maxImageDimension` | breaking (parse) |
| `commands/execute` → required `images` | **breaking (send)** |
| `CommandDescriptor.input.images` | additive |
| `assistant/message.interrupted` | additive |
| `web_search`: `query` → `queries[]` | breaking (tool card) |
| four `team/*` event types | additive, not composed by any shipped harness |

rc.8's two new RPCs — `fileReferences/list` and `sessionReferenceResolver/candidates`, the @-mention surface — are deliberately **not** in this PR. That is a composer feature, not a protocol fix.

## Also

- Records **[dshm.zyphite.com](https://dshm.zyphite.com)** as the project site, in the README badge row and the issue-template links.
- The mock harness now refuses a mismatched argument object the way the real gateway does, instead of accepting whatever arrives. That is what would have caught the `commands/execute` break from this side.

## Verification

`./gradlew :core:test :mock-harness:test :app:testDebugUnitTest :app:lintDebug :app:assembleDebug` — all green. New coverage: the rc.7/rc.8 describe fixtures and the capability latch, all four `commands/execute` argument shapes, the admission order against the host's own, the `interrupted` fold, and the gateway-faithful mock refusal.

Not yet verified against a live rc.8 harness — `node tools/capture/capture.mjs` (now also capturing `commands/list`) is the check.

> [!NOTE]
> The site's compatibility table still reads 0.4.0 / rc.7 and will need updating alongside this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
