### PR TITLE
Reach a harness behind an HTTPS reverse proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to DSH Mobile are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/); the project uses SemVer.
 
+## [Unreleased]
+
+### Fixed
+
+- **A harness behind an HTTPS reverse proxy could not be connected to at all**
+  (#6). Two faults compounded, one per way of typing the address. The host
+  field took its text as a bare hostname, so a pasted `https://agent.home` went
+  to DNS scheme and all — and failed with advice about running ipconfig. And
+  every URL the app built began `http://`, so even the plain hostname with port
+  443 sent cleartext to a TLS socket and was told it had found something that
+  "is not a DeepSeek Harness". The host field now reads what people actually
+  paste — scheme, port, a trailing path, IPv6 brackets — and an `https://`
+  scheme (or port 443 with no scheme) makes the whole connection TLS: every
+  `/api` call, both event streams, and session-log downloads. The choice is
+  remembered per host, so reconnects and auto-connect keep speaking it.
+- A failed TLS handshake now has its own diagnosis instead of landing in the
+  generic bucket, naming the two things it can mean: a certificate this phone
+  does not trust (install the local CA), or `https://` aimed at a plain-HTTP
+  port (drop the scheme). `SSLException` *is* an `IOException`, so before this
+  it fell through to the message sniffer and matched nothing.
+- The name-does-not-resolve message suggested only ipconfig on Windows, which
+  read as a wrong guess to anyone whose computer runs Linux or macOS (#6). It
+  now names all three.
+
+### Added
+
+- User-installed CA certificates are trusted for HTTPS connections
+  (`<certificates src="user" />`). A LAN proxy is almost always signed by a
+  local CA — Caddy's internal CA, mkcert — which only ever works if the
+  phone's owner deliberately installed it; without this entry every such setup
+  failed closed with a handshake error the app could name but not fix.
+  Verification is not otherwise relaxed: no accept-anyway flow, no hostname
+  bypass. `docs/SECURITY.md` describes the model, and `harness/README.md`
+  gained the Caddy walkthrough and a troubleshooting entry for the new
+  failure message.
+
 ## [0.6.0] - 2026-08-21
 
 The baseline moves to harness **0.1.1-rc.2**, and this one is a re-verification

--- a/app/src/main/java/com/labteto/dshmobile/connection/ConnectionManager.kt
+++ b/app/src/main/java/com/labteto/dshmobile/connection/ConnectionManager.kt
@@ -132,10 +132,15 @@ class ConnectionManager @Inject constructor(
     }
 
     /** Build a client for manual probing/prompting without the full loop. */
-    fun probeClient(host: String, port: Int): DshApiClient = DshApiClient(
-        transport = OkHttpRpcTransport("http://$host:$port", okHttpClient),
-        wsFactory = { path, sink -> WsDownlink("http://$host:$port$path", okHttpClient, sink) },
-    )
+    fun probeClient(host: String, port: Int, useTls: Boolean = false): DshApiClient {
+        // One base for the POSTs and both streams: OkHttp takes an http(s) URL for a WebSocket
+        // and upgrades it itself, so an https base is all it takes to make the streams wss.
+        val base = harnessBaseUrl(host, port, useTls)
+        return DshApiClient(
+            transport = OkHttpRpcTransport(base, okHttpClient),
+            wsFactory = { path, sink -> WsDownlink("$base$path", okHttpClient, sink) },
+        )
+    }
 
     val connectedApi: DshApiClient? get() = api
 
@@ -156,7 +161,7 @@ class ConnectionManager @Inject constructor(
             host = config,
             stage = ConnectStage.OpeningStreams,
         )
-        val client = probeClient(config.host, config.port)
+        val client = probeClient(config.host, config.port, config.useTls)
         api = client
         val loop = ConnectionLoop(client, sinks, LoopConfig())
         this.loop = loop
@@ -176,7 +181,7 @@ class ConnectionManager @Inject constructor(
     fun reconnectIfNeeded() {
         val host = activeHost ?: return
         loop?.stop()
-        val client = api ?: probeClient(host.host, host.port).also { api = it }
+        val client = api ?: probeClient(host.host, host.port, host.useTls).also { api = it }
         loop = ConnectionLoop(client, sinks, LoopConfig()).also { it.start() }
     }
 

--- a/app/src/main/java/com/labteto/dshmobile/connection/DiscoveryEngine.kt
+++ b/app/src/main/java/com/labteto/dshmobile/connection/DiscoveryEngine.kt
@@ -98,7 +98,9 @@ class DiscoveryEngine @Inject constructor(
         host: String,
         port: Int,
         timeouts: ProbeTimeouts = ProbeTimeouts.Sweep,
-    ): HostDescription? = (probeOutcome(host, port, timeouts) as? ProbeOutcome.Reachable)?.description
+        useTls: Boolean = false,
+    ): HostDescription? =
+        (probeOutcome(host, port, timeouts, useTls = useTls) as? ProbeOutcome.Reachable)?.description
 
     /**
      * Probe one authority and keep the reason it failed.
@@ -115,6 +117,7 @@ class DiscoveryEngine @Inject constructor(
         port: Int,
         timeouts: ProbeTimeouts = ProbeTimeouts.Sweep,
         preflight: Boolean = false,
+        useTls: Boolean = false,
     ): ProbeOutcome = withContext(Dispatchers.IO) {
         if (preflight) {
             preflight(host, port, timeouts.connectMs)?.let { return@withContext it }
@@ -124,7 +127,7 @@ class DiscoveryEngine @Inject constructor(
             // handed, so anything applied to the builder here would be silently replaced by the 30s
             // default — which is why this probe used to be able to block for thirty seconds.
             transport = OkHttpRpcTransport(
-                baseUrl = "http://$host:$port",
+                baseUrl = harnessBaseUrl(host, port, useTls),
                 client = okHttpClient,
                 connectTimeoutMs = timeouts.connectMs,
                 readTimeoutMs = timeouts.readMs,
@@ -140,6 +143,7 @@ class DiscoveryEngine @Inject constructor(
                 TransportFailure.DNS -> ProbeOutcome.DnsFailure
                 TransportFailure.UNREACHABLE -> ProbeOutcome.Unreachable
                 TransportFailure.NOT_FOUND, TransportFailure.NOT_A_HARNESS -> ProbeOutcome.NotAHarness
+                TransportFailure.TLS -> ProbeOutcome.TlsFailure
                 TransportFailure.OTHER, null -> ProbeOutcome.Other(result.error.message)
             }
         }

--- a/app/src/main/java/com/labteto/dshmobile/connection/HostConfig.kt
+++ b/app/src/main/java/com/labteto/dshmobile/connection/HostConfig.kt
@@ -18,13 +18,23 @@ data class HostConfig(
     val host: String,
     val port: Int,
     val isLoopback: Boolean = false,
+    /**
+     * Speak TLS to this endpoint. The harness itself never serves HTTPS — this is for a reverse
+     * proxy someone put in front of it (Caddy at `https://agent.home`, say), which is the only
+     * way it is ever reached over TLS.
+     */
+    val useTls: Boolean = false,
     val lastConnectedAt: Long = 0L,
     val lastVersion: String? = null,
     val lastCwd: String? = null,
     val lastSessions: Int? = null,
 ) {
+    /** Bare `host:port` — the identity key and display form, deliberately scheme-free. */
     val authority: String get() = "$host:$port"
-    val baseUrl: String get() = "http://$authority"
+    val baseUrl: String get() = harnessBaseUrl(host, port, useTls)
+
+    /** What a card prints: the authority, scheme-qualified only when it is not the plain default. */
+    val displayAddress: String get() = if (useTls) "https://$authority" else authority
 }
 
 /**

--- a/app/src/main/java/com/labteto/dshmobile/connection/HostInput.kt
+++ b/app/src/main/java/com/labteto/dshmobile/connection/HostInput.kt
@@ -1,0 +1,88 @@
+package com.labteto.dshmobile.connection
+
+/**
+ * What the connect form's host field actually said.
+ *
+ * People paste what they have, and what they have is usually a URL: the line the harness printed,
+ * the address bar of the working web GUI, a reverse proxy's `https://agent.home`. Handing that
+ * string to DNS as a hostname is how "https://agent.home" came to be diagnosed as a computer that
+ * does not exist (#6). This type keeps the three facts a URL can carry apart, so the caller can
+ * decide what fills the gaps.
+ */
+data class HostInput(
+    /** The bare host: an IPv4/IPv6 literal or a name, brackets and scheme stripped. */
+    val host: String,
+    /** A port the field itself named (`https://x:8443`, `x:3080`), or null. */
+    val port: Int?,
+    /** What the scheme said about TLS — `https://` true, `http://` false, no scheme null. */
+    val useTls: Boolean?,
+)
+
+/**
+ * Read the host field leniently; null means nothing connectable was typed.
+ *
+ * Accepted: a bare host, `host:port`, an `http://` or `https://` URL with optional port and an
+ * ignored path, and IPv6 literals with or without brackets. A port named here is more explicit
+ * than the separate port field (it was typed as part of an address, not left over from a previous
+ * harness), so callers let it win. Any other scheme is refused rather than guessed at.
+ */
+internal fun parseHostInput(raw: String): HostInput? {
+    val trimmed = raw.trim()
+    if (trimmed.isBlank()) return null
+
+    var useTls: Boolean? = null
+    var rest = trimmed
+    val schemeEnd = trimmed.indexOf("://")
+    if (schemeEnd >= 0) {
+        useTls = when (trimmed.take(schemeEnd).lowercase()) {
+            "http" -> false
+            "https" -> true
+            else -> return null
+        }
+        rest = trimmed.substring(schemeEnd + 3)
+    }
+
+    // A pasted URL may carry a path, query or fragment; the authority is all that names the host.
+    rest = rest.takeWhile { it != '/' && it != '?' && it != '#' }
+    if (rest.isBlank()) return null
+
+    val host: String
+    var port: Int? = null
+    when {
+        // Bracketed IPv6, the URL form: [::1] or [::1]:3080.
+        rest.startsWith("[") -> {
+            val close = rest.indexOf(']')
+            if (close <= 1) return null
+            host = rest.substring(1, close)
+            val after = rest.substring(close + 1)
+            when {
+                after.isEmpty() -> {}
+                after.startsWith(":") -> port = after.drop(1).toValidPort() ?: return null
+                else -> return null
+            }
+        }
+        // More than one colon and no brackets can only be a bare IPv6 literal — a port after an
+        // unbracketed one is unparseable, which is exactly why URLs bracket them.
+        rest.count { it == ':' } > 1 -> host = rest
+        rest.contains(':') -> {
+            host = rest.substringBefore(':')
+            port = rest.substringAfter(':').toValidPort() ?: return null
+        }
+        else -> host = rest
+    }
+    if (host.isBlank() || host.any { it.isWhitespace() }) return null
+    return HostInput(host = host, port = port, useTls = useTls)
+}
+
+private fun String.toValidPort(): Int? = toIntOrNull()?.takeIf { it in 1..65535 }
+
+/**
+ * `host:port` as a URL requires it — an IPv6 literal goes back into brackets. The display
+ * authority everywhere else stays bare; this form is only for building URLs.
+ */
+internal fun urlAuthority(host: String, port: Int): String =
+    if (':' in host) "[$host]:$port" else "$host:$port"
+
+/** The scheme-qualified base URL for one harness endpoint. */
+internal fun harnessBaseUrl(host: String, port: Int, useTls: Boolean): String =
+    (if (useTls) "https://" else "http://") + urlAuthority(host, port)

--- a/app/src/main/java/com/labteto/dshmobile/connection/HostsStore.kt
+++ b/app/src/main/java/com/labteto/dshmobile/connection/HostsStore.kt
@@ -105,6 +105,7 @@ class HostsStore @Inject constructor(
         host: String,
         port: Int,
         isLoopback: Boolean,
+        useTls: Boolean = false,
         description: HostDescription? = null,
     ): HostConfig {
         val existing = hosts.first().firstOrNull { it.host == host && it.port == port }
@@ -114,6 +115,7 @@ class HostsStore @Inject constructor(
             host = host,
             port = port,
             isLoopback = isLoopback,
+            useTls = useTls,
             lastConnectedAt = System.currentTimeMillis(),
             lastVersion = description?.version ?: existing?.lastVersion,
             lastCwd = description?.cwd ?: existing?.lastCwd,

--- a/app/src/main/java/com/labteto/dshmobile/connection/ProbeOutcome.kt
+++ b/app/src/main/java/com/labteto/dshmobile/connection/ProbeOutcome.kt
@@ -32,6 +32,12 @@ sealed interface ProbeOutcome {
     /** Something is listening, but it does not speak the harness protocol. */
     data object NotAHarness : ProbeOutcome
 
+    /**
+     * The socket opened but the TLS handshake failed — a certificate this phone does not trust,
+     * or `https://` aimed at a plain-HTTP server.
+     */
+    data object TlsFailure : ProbeOutcome
+
     /** Anything else; [detail] is the carrier's own words, for the fallback message. */
     data class Other(val detail: String) : ProbeOutcome
 }

--- a/app/src/main/java/com/labteto/dshmobile/ui/screens/connect/ConnectDiagnosis.kt
+++ b/app/src/main/java/com/labteto/dshmobile/ui/screens/connect/ConnectDiagnosis.kt
@@ -35,6 +35,9 @@ sealed interface ConnectFailure {
     /** Something is listening, but it is not a harness. */
     data object NotAHarness : ConnectFailure
 
+    /** The TLS handshake failed — an untrusted certificate, or `https://` to a plain-HTTP server. */
+    data object TlsFailure : ConnectFailure
+
     /** The API answered but the event streams would not open. */
     data object StreamsBlocked : ConnectFailure
 
@@ -54,6 +57,7 @@ sealed interface ConnectFailure {
             // first, and when it does not, "nothing answered" is the honest reading.
             ProbeOutcome.Unreachable -> Timeout
             ProbeOutcome.NotAHarness -> NotAHarness
+            ProbeOutcome.TlsFailure -> TlsFailure
             is ProbeOutcome.Other -> Other(outcome.detail)
         }
 
@@ -75,6 +79,7 @@ sealed interface ConnectFailure {
             TransportFailure.TIMEOUT, TransportFailure.UNREACHABLE -> Timeout
             TransportFailure.DNS -> DnsFailure
             TransportFailure.NOT_FOUND, TransportFailure.NOT_A_HARNESS -> NotAHarness
+            TransportFailure.TLS -> TlsFailure
             TransportFailure.OTHER -> message?.takeIf { it.isNotBlank() }?.let { Other(it) } ?: fallback
             null -> fallback
         }

--- a/app/src/main/java/com/labteto/dshmobile/ui/screens/connect/ConnectScreen.kt
+++ b/app/src/main/java/com/labteto/dshmobile/ui/screens/connect/ConnectScreen.kt
@@ -290,7 +290,7 @@ private fun RecentHarnessCard(
             )
         }
         Text(
-            listOfNotNull(host.authority, cwd?.let { basename(it) }).joinToString(" · "),
+            listOfNotNull(host.displayAddress, cwd?.let { basename(it) }).joinToString(" · "),
             style = DsType.caption11,
             color = colors.labelTertiary,
             maxLines = 1,
@@ -462,6 +462,7 @@ private fun ConnectFailureBlock(
         ConnectFailure.TrustFence -> stringResource(R.string.connect_failed_fence)
         ConnectFailure.DnsFailure -> stringResource(R.string.connect_fail_dns, authority)
         ConnectFailure.NotAHarness -> stringResource(R.string.connect_fail_not_harness, authority)
+        ConnectFailure.TlsFailure -> stringResource(R.string.connect_fail_tls, authority)
         ConnectFailure.StreamsBlocked -> stringResource(R.string.connect_fail_streams, authority)
         is ConnectFailure.Other -> stringResource(R.string.connect_fail_other, authority, failure.detail)
     }

--- a/app/src/main/java/com/labteto/dshmobile/ui/screens/connect/ConnectViewModel.kt
+++ b/app/src/main/java/com/labteto/dshmobile/ui/screens/connect/ConnectViewModel.kt
@@ -11,6 +11,7 @@ import com.labteto.dshmobile.connection.HostConfig
 import com.labteto.dshmobile.connection.HostsStore
 import com.labteto.dshmobile.connection.ProbeOutcome
 import com.labteto.dshmobile.connection.ProbeTimeouts
+import com.labteto.dshmobile.connection.parseHostInput
 import com.labteto.dshmobile.core.wire.dto.HostDescription
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CompletableDeferred
@@ -174,7 +175,7 @@ class ConnectViewModel @Inject constructor(
                 async {
                     val description = runCatching {
                         // A remembered host is named, not swept — worth waiting for.
-                        discoveryEngine.probe(host.host, host.port, ProbeTimeouts.Manual)
+                        discoveryEngine.probe(host.host, host.port, ProbeTimeouts.Manual, host.useTls)
                     }.getOrNull()
                     _state.update { current ->
                         current.copy(
@@ -204,7 +205,7 @@ class ConnectViewModel @Inject constructor(
         if (settings.autoConnectLast) {
             val last = hostsStore.hosts.first().firstOrNull()
             if (last != null) {
-                val desc = discoveryEngine.probe(last.host, last.port, ProbeTimeouts.Manual)
+                val desc = discoveryEngine.probe(last.host, last.port, ProbeTimeouts.Manual, last.useTls)
                 if (desc != null) {
                     connectTo(last)
                     return
@@ -304,14 +305,20 @@ class ConnectViewModel @Inject constructor(
     }
 
     fun connectManual(host: String, port: String) {
-        val trimmed = host.trim()
-        val portInt = port.trim().toIntOrNull()
-        if (trimmed.isBlank() || portInt == null || portInt !in 1..65535) {
+        // The field takes what people actually have — a pasted URL as readily as a bare address.
+        // A port named inside it was typed as part of this address, so it outranks the port field,
+        // which may still hold the default from a different harness.
+        val input = parseHostInput(host)
+        val portInt = input?.port ?: port.trim().toIntOrNull()
+        if (input == null || portInt == null || portInt !in 1..65535) {
             fail(ConnectFailure.InvalidInput, attempted = null)
             return
         }
-        val authority = "$trimmed:$portInt"
-        val isLoopback = trimmed == LOOPBACK || trimmed == "localhost"
+        // An explicit scheme decides; otherwise port 443 means a TLS reverse proxy — the harness
+        // itself never serves there, and plaintext to a TLS port yields an answer no one can read.
+        val useTls = input.useTls ?: (portInt == 443)
+        val authority = "${input.host}:$portInt"
+        val isLoopback = input.host == LOOPBACK || input.host == "localhost"
 
         localStage = ConnectStage.Validating
         _state.update { it.copy(stage = ConnectStage.Validating, failure = null, attempted = authority) }
@@ -320,17 +327,18 @@ class ConnectViewModel @Inject constructor(
             // Cheap and decisive: the sweep only ever looks at this phone's own /24, so an address
             // outside it can never be reached from here and can never be found by scanning either.
             // Saying so now beats a four-second timeout that blames the firewall.
-            if (!isLoopback && !discoveryEngine.isOnLocalSubnet(trimmed)) {
+            if (!isLoopback && !discoveryEngine.isOnLocalSubnet(input.host)) {
                 fail(ConnectFailure.DifferentSubnet(discoveryEngine.localSubnetLabel()), authority)
                 return@launch
             }
             localStage = ConnectStage.Reaching
             _state.update { it.copy(stage = ConnectStage.Reaching) }
             val outcome = discoveryEngine.probeOutcome(
-                host = trimmed,
+                host = input.host,
                 port = portInt,
                 timeouts = ProbeTimeouts.Manual,
                 preflight = true,
+                useTls = useTls,
             )
             if (outcome !is ProbeOutcome.Reachable) {
                 fail(ConnectFailure.from(outcome), authority)
@@ -338,10 +346,11 @@ class ConnectViewModel @Inject constructor(
             }
             hostsStore.addKnownPort(portInt)
             val config = hostsStore.rememberHost(
-                name = hostLabel(trimmed),
-                host = trimmed,
+                name = hostLabel(input.host),
+                host = input.host,
                 port = portInt,
                 isLoopback = isLoopback,
+                useTls = useTls,
                 description = outcome.description,
             )
             connectTo(config)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -56,8 +56,9 @@
     <string name="connect_fail_timeout">لم يردّ أي شيء على %1$s. غالبًا يحجب جدار الحماية في الكمبيوتر الاتصالات الواردة على المنفذ %2$d — اسمح به ثم أعد المحاولة. بعض الراوترات تمنع أجهزة Wi-Fi من الوصول إلى الأجهزة السلكية.</string>
     <string name="connect_fail_refused">رفض %1$s الاتصال. لا يستمع الـ harness إلا على الكمبيوتر نفسه ما لم يُفعّل وضع الشبكة المحلية — فعّله وأعد تشغيله. وإن غيّرت المنفذ، تحقق من تطابقه.</string>
     <string name="connect_fail_fence_title">رفض الـ harness هذا العنوان</string>
-    <string name="connect_fail_dns">لا يوجد جهاز على هذه الشبكة يستجيب لـ “%1$s”. استخدم عنوان IP للكمبيوتر — شغّل ipconfig على ويندوز لمعرفته.</string>
+    <string name="connect_fail_dns">لا يوجد جهاز على هذه الشبكة يستجيب لـ “%1$s”. استخدم عنوان IP للكمبيوتر — يظهره ipconfig على ويندوز أو ip addr على لينكس أو ifconfig على macOS.</string>
     <string name="connect_fail_not_harness">ردّ شيء على %1$s، لكنه ليس DeepSeek Harness. تحقق من المنفذ الذي طبعه عند بدء التشغيل.</string>
+    <string name="connect_fail_tls">ردّ %1$s، لكن الاتصال الآمن (HTTPS) فشل. إذا كان الوكيل لديك يستخدم مرجع شهادات محليًا، فثبّت شهادة CA الخاصة به على هذا الهاتف — وإذا كان العنوان لا يقدّم HTTPS فعلًا، فاتصل من دون https://.</string>
     <string name="connect_fail_streams">ردّ %1$s، لكن مسار الأحداث لم يُفتح. قد تحجب شبكة VPN أو وكيل DNS خاص اتصالات WebSocket — أوقفه ثم أعد المحاولة.</string>
     <string name="connect_fail_other">تعذّر الاتصال بـ %1$s. %2$s</string>
     <string name="connect_version_mismatch">قد يكون إصدار Harness %1$s غير متوافق مع هذا التطبيق (المبني للإصدار %2$s).</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -56,8 +56,9 @@
     <string name="connect_fail_timeout">%1$s-এ কিছুই সাড়া দেয়নি। সাধারণত কম্পিউটারের ফায়ারওয়াল %2$d পোর্টে ইনকামিং সংযোগ আটকাচ্ছে — অনুমতি দিয়ে আবার চেষ্টা করুন। কিছু রাউটার ওয়াই-ফাই ডিভাইসকে তারযুক্ত ডিভাইসে পৌঁছাতে দেয় না।</string>
     <string name="connect_fail_refused">%1$s সংযোগ প্রত্যাখ্যান করেছে। LAN মোড চালু না করলে harness কেবল কম্পিউটারেই শোনে — চালু করে harness রিস্টার্ট করুন। পোর্ট বদলালে সেটিও মিলিয়ে দেখুন।</string>
     <string name="connect_fail_fence_title">harness এই ঠিকানা প্রত্যাখ্যান করেছে</string>
-    <string name="connect_fail_dns">এই নেটওয়ার্কে “%1$s” নামে কোনো ডিভাইস সাড়া দেয় না। বরং কম্পিউটারের IP ঠিকানা ব্যবহার করুন — উইন্ডোজে ipconfig চালান।</string>
+    <string name="connect_fail_dns">এই নেটওয়ার্কে “%1$s” নামে কোনো ডিভাইস সাড়া দেয় না। বরং কম্পিউটারের IP ঠিকানা ব্যবহার করুন — Windows-এ ipconfig, Linux-এ ip addr, macOS-এ ifconfig দিয়ে জানা যায়।</string>
     <string name="connect_fail_not_harness">%1$s-এ কিছু সাড়া দিয়েছে, কিন্তু সেটি DeepSeek Harness নয়। harness চালু হওয়ার সময় দেখানো পোর্টটি দেখুন।</string>
+    <string name="connect_fail_tls">%1$s সাড়া দিয়েছে, কিন্তু নিরাপদ (HTTPS) সংযোগ ব্যর্থ হয়েছে। আপনার প্রক্সি লোকাল সার্টিফিকেট অথরিটি ব্যবহার করলে তার CA সার্টিফিকেট এই ফোনে ইনস্টল করুন — আর ঠিকানাটি আসলে HTTPS না দিলে https:// ছাড়া সংযোগ করুন।</string>
     <string name="connect_fail_streams">%1$s সাড়া দিয়েছে, কিন্তু ইভেন্ট স্ট্রিম খোলেনি। এই ফোনে VPN বা প্রাইভেট DNS প্রক্সি WebSocket সংযোগ আটকাতে পারে — বন্ধ করে আবার চেষ্টা করুন।</string>
     <string name="connect_fail_other">%1$s-এ সংযোগ করা যায়নি। %2$s</string>
     <string name="connect_version_mismatch">Harness সংস্করণ %1$s এই অ্যাপের (যা %2$s-এর জন্য তৈরি) সাথে অসামঞ্জস্যপূর্ণ হতে পারে।</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -56,8 +56,9 @@
     <string name="connect_fail_timeout">Nada respondió en %1$s. Normalmente el firewall del ordenador bloquea las conexiones entrantes en el puerto %2$d: permítelas y vuelve a intentarlo. Algunos routers también impiden que los dispositivos Wi-Fi lleguen a los de cable.</string>
     <string name="connect_fail_refused">%1$s rechazó la conexión. El harness solo escucha en el propio ordenador salvo que actives el modo LAN: actívalo y reinicia el harness. Si cambiaste el puerto, comprueba que coincide.</string>
     <string name="connect_fail_fence_title">El harness rechazó esta dirección</string>
-    <string name="connect_fail_dns">Ningún dispositivo de esta red responde a “%1$s”. Usa la dirección IP del ordenador: ejecuta ipconfig en Windows para averiguarla.</string>
+    <string name="connect_fail_dns">Ningún dispositivo de esta red responde a “%1$s”. Usa la dirección IP del ordenador: se ve con ipconfig en Windows, ip addr en Linux o ifconfig en macOS.</string>
     <string name="connect_fail_not_harness">Algo respondió en %1$s, pero no es un DeepSeek Harness. Comprueba el puerto que mostró el harness al arrancar.</string>
+    <string name="connect_fail_tls">%1$s respondió, pero la conexión segura (HTTPS) falló. Si tu proxy usa una autoridad certificadora local, instala su certificado CA en este teléfono — y si la dirección en realidad no sirve HTTPS, conéctate sin https://.</string>
     <string name="connect_fail_streams">%1$s respondió, pero su flujo de eventos no se abrió. Una VPN o un proxy de DNS privado en este teléfono puede bloquear las conexiones WebSocket: desactívalo y vuelve a intentarlo.</string>
     <string name="connect_fail_other">No se pudo conectar con %1$s. %2$s</string>
     <string name="connect_version_mismatch">La versión %1$s del Harness puede ser incompatible con esta app (diseñada para %2$s).</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -56,8 +56,9 @@
     <string name="connect_fail_timeout">Aucune réponse à %1$s. Le pare-feu de l\'ordinateur bloque généralement les connexions entrantes sur le port %2$d — autorisez-les puis réessayez. Certains routeurs empêchent aussi les appareils Wi-Fi d\'atteindre ceux en filaire.</string>
     <string name="connect_fail_refused">%1$s a refusé la connexion. Le harness n\'écoute que sur l\'ordinateur lui-même tant que le mode LAN n\'est pas activé — activez-le et redémarrez le harness. Si vous avez changé le port, vérifiez qu\'il correspond.</string>
     <string name="connect_fail_fence_title">Le harness a refusé cette adresse</string>
-    <string name="connect_fail_dns">Aucun appareil de ce réseau ne répond à “%1$s”. Utilisez plutôt l\'adresse IP de l\'ordinateur — exécutez ipconfig sous Windows pour la trouver.</string>
+    <string name="connect_fail_dns">Aucun appareil de ce réseau ne répond à “%1$s”. Utilisez plutôt l\'adresse IP de l\'ordinateur — trouvez-la avec ipconfig sous Windows, ip addr sous Linux ou ifconfig sous macOS.</string>
     <string name="connect_fail_not_harness">Quelque chose a répondu à %1$s, mais ce n\'est pas un DeepSeek Harness. Vérifiez le port affiché par le harness au démarrage.</string>
+    <string name="connect_fail_tls">%1$s a répondu, mais la connexion sécurisée (HTTPS) a échoué. Si votre proxy utilise une autorité de certification locale, installez son certificat CA sur ce téléphone — et si l\'adresse ne propose pas réellement HTTPS, connectez-vous sans https://.</string>
     <string name="connect_fail_streams">%1$s a répondu, mais son flux d\'événements ne s\'est pas ouvert. Un VPN ou un proxy DNS privé sur ce téléphone peut bloquer les connexions WebSocket — désactivez-le et réessayez.</string>
     <string name="connect_fail_other">Impossible de se connecter à %1$s. %2$s</string>
     <string name="connect_version_mismatch">La version %1$s du Harness peut être incompatible avec cette application (conçue pour %2$s).</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -56,8 +56,9 @@
     <string name="connect_fail_timeout">%1$s पर कोई जवाब नहीं मिला। आमतौर पर कंप्यूटर का फ़ायरवॉल पोर्ट %2$d पर आने वाले कनेक्शन रोकता है — उसे अनुमति देकर फिर कोशिश करें। कुछ राउटर वाई-फाई डिवाइस को तार वाले डिवाइस तक पहुँचने से भी रोकते हैं।</string>
     <string name="connect_fail_refused">%1$s ने कनेक्शन अस्वीकार कर दिया। LAN मोड चालू किए बिना harness केवल कंप्यूटर पर ही सुनता है — उसे चालू करके harness पुनः आरंभ करें। पोर्ट बदला हो तो उसे भी मिलाएँ।</string>
     <string name="connect_fail_fence_title">harness ने यह पता अस्वीकार कर दिया</string>
-    <string name="connect_fail_dns">इस नेटवर्क पर “%1$s” नाम से कोई डिवाइस जवाब नहीं देता। इसके बजाय कंप्यूटर का IP पता लगाएँ — विंडोज़ पर ipconfig चलाएँ।</string>
+    <string name="connect_fail_dns">इस नेटवर्क पर “%1$s” नाम से कोई डिवाइस जवाब नहीं देता। इसके बजाय कंप्यूटर का IP पता इस्तेमाल करें — Windows पर ipconfig, Linux पर ip addr, macOS पर ifconfig से पता चलता है।</string>
     <string name="connect_fail_not_harness">%1$s पर किसी ने जवाब दिया, पर वह DeepSeek Harness नहीं है। harness ने शुरू होते समय जो पोर्ट दिखाया था, उसे जाँचें।</string>
+    <string name="connect_fail_tls">%1$s ने जवाब दिया, पर सुरक्षित (HTTPS) कनेक्शन नहीं बन सका। अगर आपका प्रॉक्सी किसी लोकल सर्टिफिकेट अथॉरिटी का उपयोग करता है, तो उसका CA सर्टिफिकेट इस फ़ोन पर इंस्टॉल करें — और अगर वह पता असल में HTTPS पर नहीं चलता, तो https:// हटाकर कनेक्ट करें।</string>
     <string name="connect_fail_streams">%1$s ने जवाब दिया, पर इसकी इवेंट स्ट्रीम नहीं खुली। इस फ़ोन पर VPN या प्राइवेट DNS प्रॉक्सी WebSocket कनेक्शन रोक सकता है — उसे बंद करके फिर कोशिश करें।</string>
     <string name="connect_fail_other">%1$s से कनेक्ट नहीं हो सका। %2$s</string>
     <string name="connect_version_mismatch">Harness संस्करण %1$s इस ऐप (जो %2$s के लिए बनाया गया है) के साथ असंगत हो सकता है।</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -56,8 +56,9 @@
     <string name="connect_fail_timeout">Nada respondeu em %1$s. Normalmente o firewall do computador bloqueia conexões de entrada na porta %2$d — permita e tente novamente. Alguns roteadores também impedem que dispositivos Wi-Fi alcancem os cabeados.</string>
     <string name="connect_fail_refused">%1$s recusou a conexão. O harness só escuta no próprio computador enquanto o modo LAN não estiver ativado — ative-o e reinicie o harness. Se você mudou a porta, confira se ela confere.</string>
     <string name="connect_fail_fence_title">O harness recusou este endereço</string>
-    <string name="connect_fail_dns">Nenhum dispositivo desta rede responde a “%1$s”. Use o endereço IP do computador — execute ipconfig no Windows para descobri-lo.</string>
+    <string name="connect_fail_dns">Nenhum dispositivo desta rede responde a “%1$s”. Use o endereço IP do computador — descubra-o com ipconfig no Windows, ip addr no Linux ou ifconfig no macOS.</string>
     <string name="connect_fail_not_harness">Algo respondeu em %1$s, mas não é um DeepSeek Harness. Confira a porta que o harness mostrou ao iniciar.</string>
+    <string name="connect_fail_tls">%1$s respondeu, mas a conexão segura (HTTPS) falhou. Se o seu proxy usa uma autoridade certificadora local, instale o certificado CA dela neste telefone — e se o endereço na verdade não serve HTTPS, conecte sem https://.</string>
     <string name="connect_fail_streams">%1$s respondeu, mas o fluxo de eventos não abriu. Uma VPN ou proxy de DNS privado neste telefone pode bloquear conexões WebSocket — desligue e tente novamente.</string>
     <string name="connect_fail_other">Não foi possível conectar a %1$s. %2$s</string>
     <string name="connect_version_mismatch">A versão %1$s do Harness pode ser incompatível com este aplicativo (desenvolvido para %2$s).</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -56,8 +56,9 @@
     <string name="connect_fail_timeout">На %1$s ничего не ответило. Обычно брандмауэр компьютера блокирует входящие подключения на порт %2$d — разрешите их и повторите. Некоторые роутеры также не дают Wi-Fi-устройствам доступ к проводным.</string>
     <string name="connect_fail_refused">%1$s отклонил подключение. Без режима LAN harness слушает только на самом компьютере — включите его и перезапустите harness. Если вы меняли порт, проверьте его.</string>
     <string name="connect_fail_fence_title">harness отклонил этот адрес</string>
-    <string name="connect_fail_dns">Ни одно устройство в этой сети не отвечает на “%1$s”. Используйте IP-адрес компьютера — выполните ipconfig в Windows.</string>
+    <string name="connect_fail_dns">Ни одно устройство в этой сети не отвечает на “%1$s”. Используйте IP-адрес компьютера — его покажет ipconfig в Windows, ip addr в Linux или ifconfig в macOS.</string>
     <string name="connect_fail_not_harness">На %1$s что-то ответило, но это не DeepSeek Harness. Проверьте порт, который harness вывел при запуске.</string>
+    <string name="connect_fail_tls">%1$s ответил, но защищённое (HTTPS) соединение не удалось. Если ваш прокси использует локальный центр сертификации, установите его CA-сертификат на этот телефон — а если адрес на самом деле не работает по HTTPS, подключайтесь без https://.</string>
     <string name="connect_fail_streams">%1$s ответил, но поток событий не открылся. VPN или прокси частного DNS на этом телефоне может блокировать WebSocket — отключите и повторите.</string>
     <string name="connect_fail_other">Не удалось подключиться к %1$s. %2$s</string>
     <string name="connect_version_mismatch">Версия Harness %1$s может быть несовместима с этим приложением (создано для %2$s).</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -56,8 +56,9 @@
     <string name="connect_fail_timeout">ไม่มีการตอบกลับจาก %1$s โดยทั่วไปไฟร์วอลล์ของคอมพิวเตอร์กำลังบล็อกการเชื่อมต่อขาเข้าที่พอร์ต %2$d — อนุญาตแล้วลองใหม่ เราเตอร์บางรุ่นก็กั้นอุปกรณ์ Wi-Fi ไม่ให้เข้าถึงอุปกรณ์แบบมีสาย</string>
     <string name="connect_fail_refused">%1$s ปฏิเสธการเชื่อมต่อ harness จะรับฟังเฉพาะบนคอมพิวเตอร์เอง จนกว่าจะเปิดโหมด LAN — เปิดแล้วรีสตาร์ท harness หากเปลี่ยนพอร์ต ให้ตรวจว่าตรงกัน</string>
     <string name="connect_fail_fence_title">harness ปฏิเสธที่อยู่นี้</string>
-    <string name="connect_fail_dns">ไม่มีอุปกรณ์ใดในเครือข่ายนี้ตอบสนองชื่อ “%1$s” ให้ใช้ที่อยู่ IP ของคอมพิวเตอร์แทน — รัน ipconfig บน Windows เพื่อดู</string>
+    <string name="connect_fail_dns">ไม่มีอุปกรณ์ใดในเครือข่ายนี้ตอบสนองชื่อ “%1$s” ให้ใช้ที่อยู่ IP ของคอมพิวเตอร์แทน — ดูได้ด้วย ipconfig บน Windows, ip addr บน Linux หรือ ifconfig บน macOS</string>
     <string name="connect_fail_not_harness">มีบางอย่างตอบกลับที่ %1$s แต่ไม่ใช่ DeepSeek Harness ให้ตรวจพอร์ตที่ harness แสดงตอนเริ่มทำงาน</string>
+    <string name="connect_fail_tls">%1$s ตอบกลับ แต่การเชื่อมต่อแบบปลอดภัย (HTTPS) ล้มเหลว หากพร็อกซีของคุณใช้หน่วยงานออกใบรับรองภายใน ให้ติดตั้งใบรับรอง CA นั้นบนโทรศัพท์เครื่องนี้ — และหากที่อยู่นั้นไม่ได้ให้บริการ HTTPS จริง ให้เชื่อมต่อโดยไม่ใส่ https://</string>
     <string name="connect_fail_streams">%1$s ตอบกลับ แต่สตรีมเหตุการณ์เปิดไม่ได้ VPN หรือพร็อกซี DNS ส่วนตัวบนโทรศัพท์อาจบล็อก WebSocket — ปิดแล้วลองใหม่</string>
     <string name="connect_fail_other">เชื่อมต่อ %1$s ไม่สำเร็จ %2$s</string>
     <string name="connect_version_mismatch">Harness เวอร์ชัน %1$s อาจเข้ากันไม่ได้กับแอปนี้ (สร้างสำหรับ %2$s)</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -56,8 +56,9 @@
     <string name="connect_fail_timeout">%1$s سے کوئی جواب نہیں آیا۔ عام طور پر کمپیوٹر کا فائیر وال پورٹ %2$d پر آنے والے کنکشن روکتا ہے — اسے اجازت دیکر دوبارہ کوشش کریں۔ کچھ راوٹر وائی فائی آلات کو تار والے آلات تک پہنچنے سے بھی روکتے ہیں۔</string>
     <string name="connect_fail_refused">%1$s نے کنکشن مسترد کر دیا۔ LAN موڈ فعال کیے بغیر harness صرف کمپیوٹر پر ہی سنتا ہے — اسے فعال کرکے harness دوبارہ چلائیں۔ اگر پورٹ بدلا ہے تو اسے بھی جانچیں۔</string>
     <string name="connect_fail_fence_title">harness نے یہ پتہ مسترد کر دیا</string>
-    <string name="connect_fail_dns">اس نیٹ ورک پر کوئی آلہ “%1$s” کا جواب نہیں دیتا۔ اس کے بجائے کمپیوٹر کا IP پتہ استعمال کریں — ونڈوز پر ipconfig چلائیں۔</string>
+    <string name="connect_fail_dns">اس نیٹ ورک پر کوئی آلہ “%1$s” کا جواب نہیں دیتا۔ اس کے بجائے کمپیوٹر کا IP پتہ استعمال کریں — ونڈوز پر ipconfig، لینکس پر ip addr، اور macOS پر ifconfig سے معلوم ہوتا ہے۔</string>
     <string name="connect_fail_not_harness">%1$s پر کسی چیز نے جواب دیا، مگر وہ DeepSeek Harness نہیں۔ وہ پورٹ دیکھیں جو harness نے شروع ہوتے وقت دکھایا تھا۔</string>
+    <string name="connect_fail_tls">%1$s نے جواب دیا، مگر محفوظ (HTTPS) کنکشن قائم نہ ہو سکا۔ اگر آپ کا پراکسی مقامی سرٹیفکیٹ اتھارٹی استعمال کرتا ہے تو اس کا CA سرٹیفکیٹ اس فون پر انسٹال کریں — اور اگر وہ پتہ درحقیقت HTTPS پیش نہیں کرتا تو https:// کے بغیر جڑیں۔</string>
     <string name="connect_fail_streams">%1$s نے جواب دیا، مگر اس کی ایونٹ اسٹریم نہیں کھلی۔ اس فون پر VPN یا پرائیویٹ DNS پراکسی WebSocket کو روک سکتا ہے — اسے بند کرکے دوبارہ کوشش کریں۔</string>
     <string name="connect_fail_other">%1$s سے جڑنا ممکن نہیں ہوا۔ %2$s</string>
     <string name="connect_version_mismatch">Harness ورژن %1$s اس ایپ (جو %2$s کے لیے بنائی گئی ہے) کے ساتھ مطابقت نہیں رکھتا۔</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -56,8 +56,9 @@
     <string name="connect_fail_timeout">%1$s 没有任何响应。通常是电脑的防火墙拦截了端口 %2$d 的入站连接 — 允许后重试。部分路由器也会阻止 Wi-Fi 设备访问有线设备。</string>
     <string name="connect_fail_refused">%1$s 拒绝了连接。未启用 LAN 模式时，harness 只在电脑本机监听 — 请启用并重启 harness。如果改过端口，请确认是否一致。</string>
     <string name="connect_fail_fence_title">harness 拒绝了该地址</string>
-    <string name="connect_fail_dns">该网络上没有设备响应“%1$s”。请改用电脑的 IP 地址 — 在 Windows 上运行 ipconfig 可以查到。</string>
+    <string name="connect_fail_dns">该网络上没有设备响应“%1$s”。请改用电脑的 IP 地址 — 在 Windows 上用 ipconfig、Linux 上用 ip addr、macOS 上用 ifconfig 查看。</string>
     <string name="connect_fail_not_harness">%1$s 有响应，但它不是 DeepSeek Harness。请核对 harness 启动时打印的端口。</string>
+    <string name="connect_fail_tls">%1$s 有响应，但安全（HTTPS）连接失败。若你的反向代理使用本地证书颁发机构，请在本手机上安装其 CA 证书；若该地址实际上并不提供 HTTPS，请去掉 https:// 再连接。</string>
     <string name="connect_fail_streams">%1$s 有响应，但事件流无法打开。本机的 VPN 或私有 DNS 代理可能会拦截 WebSocket 连接 — 关闭后重试。</string>
     <string name="connect_fail_other">无法连接到 %1$s。%2$s</string>
     <string name="connect_version_mismatch">Harness %1$s 版本可能与本应用（为 %2$s 构建）不兼容。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,8 +65,9 @@
     <string name="connect_fail_timeout">Nothing answered at %1$s. Usually the computer\'s firewall is blocking incoming connections on port %2$d — allow it and try again. Some routers also stop Wi-Fi devices from reaching wired ones.</string>
     <string name="connect_fail_refused">%1$s refused the connection. The harness only listens on the computer itself unless LAN mode is enabled — enable it and restart the harness. If you changed the port, check it matches.</string>
     <string name="connect_fail_fence_title">The harness rejected this address</string>
-    <string name="connect_fail_dns">No device on this network answers to “%1$s”. Use the computer\'s IP address instead — run ipconfig on Windows to find it.</string>
+    <string name="connect_fail_dns">No device on this network answers to “%1$s”. Use the computer\'s IP address instead — find it with ipconfig on Windows, ip addr on Linux, or ifconfig on macOS.</string>
     <string name="connect_fail_not_harness">Something answered at %1$s, but it is not a DeepSeek Harness. Check the port the harness printed when it started.</string>
+    <string name="connect_fail_tls">%1$s answered, but the secure (HTTPS) connection failed. If your proxy uses a local certificate authority, install its CA certificate on this phone — and if the address does not actually serve HTTPS, connect without https://.</string>
     <string name="connect_fail_streams">%1$s answered, but its event stream would not open. A VPN or private-DNS proxy on this phone can block WebSocket connections — turn it off and try again.</string>
     <string name="connect_fail_other">Could not connect to %1$s. %2$s</string>
     <string name="connect_version_mismatch">Harness version %1$s may be incompatible with this app (built for %2$s).</string>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -3,11 +3,20 @@
      required to reach it. Cleartext traffic only ever goes to a LAN host the
      user entered or picked from a scan; the one request that leaves the network
      is the GitHub release check, which is HTTPS and can be switched off.
+
+     User-installed CAs are trusted alongside the system set: the only way a
+     harness is ever reached over HTTPS is through a reverse proxy the user
+     put in front of it themselves, and such a proxy is almost always signed
+     by a local CA (Caddy's internal CA, mkcert, a homelab CA) that only the
+     phone's owner can have installed — a deliberate act Android itself warns
+     about. Without this entry every such setup fails closed with a handshake
+     error the app can name but not fix.
      See docs/SECURITY.md for the trust model. -->
 <network-security-config>
     <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
+            <certificates src="user" />
         </trust-anchors>
     </base-config>
 </network-security-config>

--- a/app/src/test/java/com/labteto/dshmobile/connection/HostInputTest.kt
+++ b/app/src/test/java/com/labteto/dshmobile/connection/HostInputTest.kt
@@ -1,0 +1,81 @@
+package com.labteto.dshmobile.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The host field takes what people actually have, which is usually a pasted URL: the line the
+ * harness printed, or a reverse proxy's address bar. Before this parser existed, the field's text
+ * went to DNS verbatim — so "https://agent.home" was reported as a computer that does not exist,
+ * with advice about ipconfig (#6).
+ */
+class HostInputTest {
+
+    @Test
+    fun `a bare host says nothing about port or tls`() {
+        assertEquals(HostInput("192.168.1.20", null, null), parseHostInput("192.168.1.20"))
+        assertEquals(HostInput("agent.home", null, null), parseHostInput("agent.home"))
+        assertEquals(HostInput("localhost", null, null), parseHostInput(" localhost "))
+    }
+
+    @Test
+    fun `a scheme decides tls in either direction`() {
+        assertEquals(HostInput("agent.home", null, true), parseHostInput("https://agent.home"))
+        assertEquals(HostInput("agent.home", null, false), parseHostInput("http://agent.home"))
+        assertEquals(HostInput("agent.home", null, true), parseHostInput("HTTPS://agent.home"))
+    }
+
+    @Test
+    fun `a port typed into the host field is kept`() {
+        assertEquals(HostInput("192.168.1.20", 3080, null), parseHostInput("192.168.1.20:3080"))
+        assertEquals(HostInput("agent.home", 8443, true), parseHostInput("https://agent.home:8443"))
+        assertEquals(HostInput("127.0.0.1", 3080, false), parseHostInput("http://127.0.0.1:3080"))
+    }
+
+    /** The harness prints its URL with a trailing slash, and the GUI's address bar carries paths. */
+    @Test
+    fun `paths queries and fragments are not part of the host`() {
+        assertEquals(HostInput("192.168.1.20", 3080, false), parseHostInput("http://192.168.1.20:3080/"))
+        assertEquals(HostInput("agent.home", null, true), parseHostInput("https://agent.home/chat?x=1#top"))
+        assertEquals(HostInput("agent.home", null, null), parseHostInput("agent.home/chat"))
+    }
+
+    @Test
+    fun `ipv6 literals survive with and without brackets`() {
+        assertEquals(HostInput("::1", null, null), parseHostInput("::1"))
+        assertEquals(HostInput("::1", null, null), parseHostInput("[::1]"))
+        assertEquals(HostInput("::1", 3080, null), parseHostInput("[::1]:3080"))
+        assertEquals(HostInput("fe80::1", 3080, false), parseHostInput("http://[fe80::1]:3080"))
+    }
+
+    @Test
+    fun `unusable input is refused rather than guessed at`() {
+        assertNull(parseHostInput(""))
+        assertNull(parseHostInput("   "))
+        assertNull(parseHostInput("ftp://agent.home"))
+        assertNull(parseHostInput("https://"))
+        assertNull(parseHostInput("agent.home:notaport"))
+        assertNull(parseHostInput("agent.home:70000"))
+        assertNull(parseHostInput("agent.home:0"))
+        assertNull(parseHostInput("[::1"))
+        assertNull(parseHostInput("[]:3080"))
+        assertNull(parseHostInput("[::1]3080"))
+        assertNull(parseHostInput("http:///chat"))
+        assertNull(parseHostInput("a b"))
+    }
+
+    @Test
+    fun `url authorities bracket ipv6 literals and leave everything else alone`() {
+        assertEquals("192.168.1.20:3080", urlAuthority("192.168.1.20", 3080))
+        assertEquals("agent.home:443", urlAuthority("agent.home", 443))
+        assertEquals("[::1]:3080", urlAuthority("::1", 3080))
+    }
+
+    @Test
+    fun `base urls carry the scheme the endpoint needs`() {
+        assertEquals("http://192.168.1.20:3080", harnessBaseUrl("192.168.1.20", 3080, useTls = false))
+        assertEquals("https://agent.home:443", harnessBaseUrl("agent.home", 443, useTls = true))
+        assertEquals("http://[::1]:3080", harnessBaseUrl("::1", 3080, useTls = false))
+    }
+}

--- a/app/src/test/java/com/labteto/dshmobile/ui/screens/connect/ConnectDiagnosisTest.kt
+++ b/app/src/test/java/com/labteto/dshmobile/ui/screens/connect/ConnectDiagnosisTest.kt
@@ -22,6 +22,7 @@ class ConnectDiagnosisTest {
         assertEquals(ConnectFailure.Timeout, ConnectFailure.from(ProbeOutcome.Timeout))
         assertEquals(ConnectFailure.DnsFailure, ConnectFailure.from(ProbeOutcome.DnsFailure))
         assertEquals(ConnectFailure.NotAHarness, ConnectFailure.from(ProbeOutcome.NotAHarness))
+        assertEquals(ConnectFailure.TlsFailure, ConnectFailure.from(ProbeOutcome.TlsFailure))
     }
 
     /** No route is a different-network problem; "nothing answered" is the honest reading. */
@@ -59,6 +60,10 @@ class ConnectDiagnosisTest {
         assertEquals(
             ConnectFailure.Timeout,
             ConnectFailure.from(GenerationFailure.StreamFailed(TransportFailure.TIMEOUT, null)),
+        )
+        assertEquals(
+            ConnectFailure.TlsFailure,
+            ConnectFailure.from(GenerationFailure.StreamFailed(TransportFailure.TLS, "handshake failed")),
         )
     }
 

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/TransportFailure.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/TransportFailure.kt
@@ -12,6 +12,7 @@ import java.net.NoRouteToHostException
 import java.net.PortUnreachableException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import javax.net.ssl.SSLException
 
 /**
  * Why a carrier-level call did not produce an answer.
@@ -43,6 +44,12 @@ enum class TransportFailure {
 
     /** Something answered, but it does not speak the harness protocol. */
     NOT_A_HARNESS,
+
+    /**
+     * The TCP connection opened but the TLS handshake did not survive it: a certificate this
+     * device does not trust, or `https://` aimed at a server speaking plain HTTP.
+     */
+    TLS,
 
     /** Anything else. */
     OTHER,
@@ -83,6 +90,9 @@ object TransportFailures {
         is UnknownHostException -> TransportFailure.DNS
         is NoRouteToHostException, is PortUnreachableException -> TransportFailure.UNREACHABLE
         is ConnectException -> TransportFailure.REFUSED
+        // Before the IOException arm: SSLException is an IOException, and its message would
+        // otherwise be sniffed for words it does not contain.
+        is SSLException -> TransportFailure.TLS
         is IOException -> classifyByMessage(t)
         else -> TransportFailure.OTHER
     }

--- a/core/src/test/kotlin/com/labteto/dshmobile/core/wire/TransportFailureTest.kt
+++ b/core/src/test/kotlin/com/labteto/dshmobile/core/wire/TransportFailureTest.kt
@@ -10,6 +10,8 @@ import java.net.NoRouteToHostException
 import java.net.PortUnreachableException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import javax.net.ssl.SSLException
+import javax.net.ssl.SSLHandshakeException
 
 class TransportFailureTest {
 
@@ -37,6 +39,23 @@ class TransportFailureTest {
         assertEquals(TransportFailure.UNREACHABLE, TransportFailures.classify(PortUnreachableException()))
         assertEquals(TransportFailure.REFUSED, TransportFailures.classify(ConnectException()))
         assertEquals(TransportFailure.OTHER, TransportFailures.classify(null as Throwable?))
+    }
+
+    /**
+     * SSLException is an IOException, so ordering matters: reaching the message sniffer would
+     * read "Unrecognized SSL message" as OTHER and blame nothing in particular, when the actual
+     * diagnosis — a certificate this device does not trust, or https:// at a plain-HTTP server —
+     * has its own advice.
+     */
+    @Test
+    fun `tls failures classify as their own kind`() {
+        assertEquals(TransportFailure.TLS, TransportFailures.classify(SSLHandshakeException("no trust anchor")))
+        assertEquals(
+            TransportFailure.TLS,
+            TransportFailures.classify(SSLException("Unrecognized SSL message, plaintext connection?")),
+        )
+        val wrapped = RpcTransportException(0, "transport failure", SSLHandshakeException("no trust anchor"))
+        assertEquals(TransportFailure.TLS, TransportFailures.classify(wrapped))
     }
 
     /**

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -13,7 +13,8 @@ not authentication:
   server binds `0.0.0.0`).
 - There are no tokens, cookies, or TLS. Any device on the same network can
   send requests with a trusted `Host` and drive the agent — including
-  running commands on the host computer.
+  running commands on the host computer. (TLS can be added from outside by
+  fronting the harness with a reverse proxy; see below.)
 
 **Consequences:**
 
@@ -25,10 +26,34 @@ not authentication:
   file pickers) remain loopback-only by harness design and are shown
   read-only over the network.
 
+## HTTPS through a reverse proxy
+
+The harness itself never serves TLS, but the app can reach one behind a
+reverse proxy that does (Caddy at `https://agent.home`, say). Typing
+`https://…` into the connect screen — or a bare address with port 443 —
+makes the whole connection TLS: every `/api` call, both event streams, and
+session-log downloads.
+
+Certificate verification is standard Android, with one addition:
+
+- The app trusts the system CA set **plus CAs the user has installed** on the
+  phone (`<certificates src="user" />`). A LAN proxy is almost always signed
+  by a local CA — Caddy's internal CA, mkcert, a homelab CA — which only
+  works if the phone's owner has deliberately installed that CA, an act
+  Android itself warns about and marks. The app adds no CAs of its own.
+- Verification is never relaxed beyond that. There is no "accept this
+  certificate anyway" flow, no hostname-check bypass, and no pinning UI: an
+  untrusted certificate fails the connection with a message naming the CA
+  install as the fix.
+- The trust fence still applies through a proxy. The app sends the authority
+  it was given as the `Host` header, so the harness must be started with
+  `--trusted-host <that name>` (a proxy that preserves `Host`, as Caddy does
+  by default, changes nothing about this).
+
 ## What DSH Mobile stores
 
-- Remembered host addresses (host, port, display name) and app preferences,
-  in app-private storage only.
+- Remembered host addresses (host, port, display name, and whether to use
+  HTTPS) and app preferences, in app-private storage only.
 - No session content is persisted to disk in v1 (chat history lives in
   memory and is re-fetched on connect).
 - The app allows cleartext HTTP by necessity (the harness serves plain

--- a/harness/README.md
+++ b/harness/README.md
@@ -49,6 +49,39 @@ configuration seam.
 4. In DSH Mobile: Settings → Connect, tap **Scan network**, or enter
    `192.168.1.20` / `3080` manually.
 
+## HTTPS via your own reverse proxy
+
+The harness never serves TLS itself, but the app can connect through a
+reverse proxy that does — Caddy, nginx, Traefik — for setups like
+`https://agent.home` on a homelab. What has to be true:
+
+1. **The proxy terminates TLS and forwards to the harness** (loopback or the
+   LAN bind above). With Caddy that is the whole Caddyfile:
+
+   ```
+   agent.home {
+       reverse_proxy 127.0.0.1:3080
+   }
+   ```
+
+2. **The harness trusts the proxy's hostname.** The app (like a browser)
+   sends `Host: agent.home`, and Caddy forwards it unchanged, so:
+
+   ```sh
+   dsh web --trusted-host agent.home
+   ```
+
+3. **The phone trusts the certificate.** A LAN proxy is usually signed by a
+   local CA (Caddy's internal CA, mkcert); install that CA certificate on the
+   phone (Android: Settings → Security → Install a certificate → CA
+   certificate). A certificate the phone does not trust fails the connect
+   with the HTTPS message below.
+
+4. In the app, enter `https://agent.home` in the host field — or just the
+   hostname with port 443, which the app reads as HTTPS. A port typed inside
+   the host field (`https://agent.home:8443`) wins over the port field, so
+   pasting the proxy's URL as-is works.
+
 ## Troubleshooting
 
 The app names the failure it hit; find that heading below. Everything here is run on the
@@ -95,6 +128,17 @@ The address you typed is outside the phone's own /24, so nothing on the phone ca
 **Scan network** cannot find it either, since the sweep only walks the phone's own subnet. Different
 bands of one SSID (2.4 GHz vs 5 GHz) are normally the same subnet and are fine; a *guest* SSID
 usually is not. Compare `ipconfig` on the computer with the address the app reports.
+
+### "The secure (HTTPS) connection failed"
+
+The socket opened but the TLS handshake did not survive it. Two causes, in order of likelihood:
+
+- **The phone does not trust the certificate.** Install the CA that signed the proxy's
+  certificate on the phone (step 3 above). Caddy's internal root lives at
+  `~/.local/share/caddy/pki/authorities/local/root.crt` on the proxy host.
+- **The address does not actually serve HTTPS.** `https://` typed at a plain-HTTP harness port
+  gets an answer TLS cannot read. Connect without `https://` — the harness's own port speaks
+  plain HTTP, always.
 
 ### "Its event stream would not open"
 


### PR DESCRIPTION
Fixes #6.

Both of the reporter's attempts failed for different reasons that compounded:

- **`agent.home` + port 443** — every URL the app built was hardcoded `http://`, so it sent cleartext to Caddy's TLS socket and the unreadable answer was diagnosed as "not a DeepSeek Harness".
- **`https://agent.home` + port 443** — the host field was used verbatim as a hostname, so the whole URL went to DNS and failed, with the misleading ipconfig hint.

## What changed

- **New parser (`HostInput.kt`)**: the host field accepts what people actually paste — `http(s)://` schemes, an embedded port (which outranks the port field), trailing paths, IPv6 literals with or without brackets. Unsupported schemes are refused as invalid input rather than guessed at.
- **TLS end to end**: `https://` (or port 443 with no scheme — the harness itself never serves there, and plaintext to a TLS port can never succeed) switches the whole connection to TLS: every `/api` call, both event streams (OkHttp upgrades an `https` URL to wss itself), and session-log downloads. The choice is persisted on `HostConfig` with a serialization default so stored host lists survive the upgrade, and reconnects, liveness probes and auto-connect honor it. Recent cards show `https://host:port` for TLS hosts.
- **A real TLS diagnosis**: `SSLException` is an `IOException`, so handshake failures fell through to the message sniffer and matched nothing. The new `TransportFailure.TLS` kind flows through `ProbeOutcome` and `ConnectFailure` to a message naming the two causes it can have — a certificate this phone does not trust (install the local CA), or `https://` aimed at a plain-HTTP port (drop the scheme).
- **User-installed CAs are trusted** (`<certificates src="user" />`): a LAN proxy is nearly always signed by a local CA (Caddy's internal CA, mkcert) that the phone's owner installed deliberately. Verification is not otherwise relaxed — no accept-anyway flow, no hostname bypass.
- **Message fix**: the DNS-failure string names `ipconfig` on Windows, `ip addr` on Linux and `ifconfig` on macOS instead of Windows alone. Both new/changed strings are translated in all ten locales.
- **Docs**: `harness/README.md` gains a Caddy walkthrough (proxy config, `--trusted-host agent.home`, installing the CA on the phone) and a troubleshooting entry for the new failure message; `docs/SECURITY.md` describes the HTTPS trust model; changelog entry under Unreleased.

## Testing

- New `HostInputTest` (8 cases over the parser), plus new TLS-classification and diagnosis-mapping cases in `TransportFailureTest` and `ConnectDiagnosisTest`.
- `:core:test`, `:app:testDebugUnitTest`, `:mock-harness:test`, `:app:lintDebug` and `:app:assembleDebug` all pass locally.