### PR TITLE
Stop claiming the relay omits Retry-After on a lockout

### DIFF
--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/RelayPairing.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/RelayPairing.kt
@@ -48,8 +48,10 @@ object RelayPairing {
     /**
      * Fallback back-off when a 429 arrives without `Retry-After`.
      *
-     * The relay's rate limiter sets that header but its pairing lockout does not, so a client that
-     * trusted it to be present would busy-retry against a locked-out address.
+     * Current relays set the header on every 429, but older ones did not on the pairing and
+     * sign-in lockout paths, and a client that trusted it to be present would busy-retry against a
+     * locked-out address. Defaulting costs nothing and removes the dependency on which relay
+     * answered.
      */
     const val DEFAULT_RETRY_AFTER_SECONDS: Long = 60
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -266,7 +266,7 @@ method that credential may not reach.
 |---|---|---|
 | 403 | no usable credential | Stops the loop and says "pair again". No backoff — there is nothing to wait for. |
 | 404 | path not proxied, or the harness lacks the capability | Existing `capability-unavailable` handling |
-| 429 | rate limited or locked out | Backs off for `Retry-After`, defaulting to 60s when the header is absent |
+| 429 | rate limited or locked out | Backs off for `Retry-After`, defaulting to 60s when the header is absent — older relays omitted it on the lockout paths |
 | 502 | the harness behind the relay is not answering | Existing reconnect handling |
 
 403 is ambiguous with the harness's own `Host` fence, and no header on a rejected


### PR DESCRIPTION
A comment and a docs line that described a relay defect which has since been
fixed upstream.

`dsh-relay` used to answer 429 without `Retry-After` on both the pairing and
sign-in lockout paths, which is why this client carries a 60-second default.
[sorsama/deepseek-harness-relay@6c14082](https://github.com/sorsama/deepseek-harness-relay/commit/6c14082)
sets the header everywhere, so the note now points at a bug that is not there.

The default itself stays — it costs nothing, and it is what keeps the client's
back-off independent of which relay version answered.

No behaviour change; comment and documentation only.
