### PR TITLE
Send the requestId harness 0.1.2 requires, so messages send at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to DSH Mobile are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/); the project uses SemVer.
 
+## [0.9.3] - 2026-08-29
+
+### Fixed
+
+- **Sending a message always failed against a harness 0.1.2.** Connecting,
+  listing sessions, reading history and choosing a model all worked, so the app
+  looked healthy right up to the moment you sent anything — at which point the
+  gateway answered `wire field "request" failed boundary validation` and the
+  text never reached an agent. 0.1.2 made `requestId` a required field of both
+  `session/prompt` and `subagents/prompt`: an identity the sender mints, one per
+  human message, which the host persists on the message the prompt is accepted
+  as. This client sent no such field on either call. Both requests carry one
+  now, minted per message.
+
+  It is validated *inside* the request object rather than beside the other
+  arguments, which is why nothing else on the surface was affected and why the
+  refusal named a field rather than a missing argument.
+
+  Reported by @snailium, who traced it to both DTOs and confirmed against a
+  live 0.1.2-alpha.1 that the same call succeeds with an id and fails without
+  one.
+
+### Changed
+
+- **The mock harness now holds a request object to the host's required
+  fields.** It matched the outer argument keys and stopped there, one layer
+  above where this bug lived, and implemented neither prompt endpoint at all —
+  so no test in the repo had ever sent a message. Both endpoints are registered
+  now, refusing a missing required field the way the real gateway does, and the
+  suite sends real prompts through the real client against them.
+
 ## [0.9.2] - 2026-08-28
 
 Verified on an Android emulator against a live relay, which is how the first

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
  * upgrade at all. The code is derived from the name so it rises with semver on its own; the
  * fallback is what a local `assembleRelease` builds.
  */
-val dshVersionName: String = System.getenv("DSH_VERSION_NAME")?.takeIf { it.isNotBlank() } ?: "0.9.2"
+val dshVersionName: String = System.getenv("DSH_VERSION_NAME")?.takeIf { it.isNotBlank() } ?: "0.9.3"
 
 val dshVersionCode: Int = dshVersionName
     .substringBefore('-')

--- a/app/src/main/java/com/labteto/dshmobile/data/SessionStore.kt
+++ b/app/src/main/java/com/labteto/dshmobile/data/SessionStore.kt
@@ -84,6 +84,7 @@ import com.labteto.dshmobile.core.wire.dto.WorkspaceValue
 import com.labteto.dshmobile.core.wire.dto.WorkspaceView
 import com.labteto.dshmobile.core.wire.dto.imageRejectionOf
 import com.labteto.dshmobile.core.wire.encodeToJsonElement
+import com.labteto.dshmobile.core.wire.newPromptRequestId
 import java.io.OutputStream
 import java.time.Instant
 import java.util.TimeZone
@@ -1405,6 +1406,7 @@ class SessionStore @Inject constructor(
         val safeMode = if (mode == "steer") "steer" else "queue"
         val zone = TimeZone.getDefault().id
         val request = SessionPromptRequest(
+            requestId = newPromptRequestId(),
             sessionId = sid,
             mode = safeMode,
             content = content,
@@ -1646,6 +1648,7 @@ class SessionStore @Inject constructor(
         val api = apiOrNull() ?: return
         val zone = TimeZone.getDefault().id
         val request = SubagentPromptRequest(
+            requestId = newPromptRequestId(),
             parentSessionId = sid,
             childSessionId = childSessionId,
             mode = "continuable",

--- a/app/src/test/java/com/labteto/dshmobile/connection/ProtocolEndToEndTest.kt
+++ b/app/src/test/java/com/labteto/dshmobile/connection/ProtocolEndToEndTest.kt
@@ -20,7 +20,13 @@ import com.labteto.dshmobile.core.wire.dto.RemoteEventOutcome
 import com.labteto.dshmobile.core.wire.dto.SessionAddress
 import com.labteto.dshmobile.core.wire.dto.SessionFollowFrame
 import com.labteto.dshmobile.core.wire.dto.SessionFollowFrameSerializer
+import com.labteto.dshmobile.core.wire.dto.SessionPromptRequest
+import com.labteto.dshmobile.core.wire.dto.SessionPromptValue
+import com.labteto.dshmobile.core.wire.dto.SubagentPromptRequest
+import com.labteto.dshmobile.core.wire.dto.ContentBlock
+import com.labteto.dshmobile.core.wire.dto.PromptContentPart
 import com.labteto.dshmobile.core.wire.decodeFromJsonElement
+import com.labteto.dshmobile.core.wire.newPromptRequestId
 import com.labteto.dshmobile.mockharness.MockHarness
 import com.labteto.dshmobile.core.session.ChunkRows
 import kotlinx.coroutines.delay
@@ -162,6 +168,81 @@ class ProtocolEndToEndTest {
             is RpcResult.Ok -> assertEquals("s1", result.value.items.single().sessionId)
             is RpcResult.Err -> error("session/list failed: ${result.error.code} ${result.error.message}")
         }
+    }
+
+    @Test
+    fun `a prompt reaches the host and carries the identity it requires`() = runBlocking {
+        // The one call every other test in this repo left alone. Connecting, listing, reading
+        // history and choosing a model all worked against a real 0.1.2 harness while sending a
+        // message could not, because no test and no mock endpoint ever sent one — so the client's
+        // request object was missing a field the host declares required and nothing said so.
+        val result = client().sessionPrompt(
+            SessionPromptRequest(
+                requestId = newPromptRequestId(),
+                sessionId = "s1",
+                mode = "queue",
+                content = listOf(PromptContentPart.Text("hello")),
+                clientTimeZone = "Asia/Bangkok",
+            ),
+        )
+        when (result) {
+            is RpcResult.Ok -> assertTrue(result.value.accepted)
+            is RpcResult.Err -> error("session/prompt failed: ${result.error.code} ${result.error.message}")
+        }
+        val received = harness.sessionPrompts.single()
+        assertTrue(received["requestId"]!!.jsonPrimitive.content.isNotBlank())
+        assertEquals("s1", received["sessionId"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `a child prompt reaches the host and carries one too`() = runBlocking {
+        val result = client().subagentPrompt(
+            SubagentPromptRequest(
+                requestId = newPromptRequestId(),
+                parentSessionId = "s1",
+                childSessionId = "c1",
+                content = listOf(ContentBlock.Text("carry on")),
+                clientTimeZone = "Asia/Bangkok",
+            ),
+        )
+        when (result) {
+            is RpcResult.Ok -> assertTrue(result.value.messageId.isNotBlank())
+            is RpcResult.Err -> error("subagents/prompt failed: ${result.error.code} ${result.error.message}")
+        }
+        assertTrue(harness.subagentPrompts.single()["requestId"]!!.jsonPrimitive.content.isNotBlank())
+    }
+
+    @Test
+    fun `a prompt without the required identity is refused the way the host refuses it`() = runBlocking {
+        // The regression itself, from the client's side: the host decodes `request` against a
+        // strict codec, so a missing required field fails at the boundary and the text never
+        // reaches an agent. Sent as a raw args object because the typed request can no longer
+        // express the broken shape — which is the point of making the field non-optional.
+        val result = client().call(
+            "session/prompt",
+            buildJsonObject {
+                putJsonObject("request") {
+                    put("sessionId", "s1")
+                    put("mode", "queue")
+                    putJsonArray("content") {
+                        addJsonObject {
+                            put("type", "text")
+                            put("text", "hello")
+                        }
+                    }
+                }
+            },
+            SessionPromptValue.serializer(),
+        )
+        val error = (result as RpcResult.Err).error
+        // A shape mismatch gets no error code of its own, which is exactly why a client cannot
+        // probe for one and must send the declared shape.
+        assertEquals("internal", error.code)
+        assertEquals(
+            "typert gateway: session/prompt: wire field \"request\" failed boundary validation",
+            error.message,
+        )
+        assertTrue(harness.sessionPrompts.isEmpty())
     }
 
     @Test

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/JsonRpc.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/JsonRpc.kt
@@ -26,6 +26,15 @@ val WireJson: Json = Json {
 /** Mint a fresh correlation id for a client-request (the initiator mints; responses echo). */
 fun newRpcId(): String = UUID.randomUUID().toString()
 
+/**
+ * Mint a fresh identity for one human prompt (`requestId` on a session or subagent prompt).
+ *
+ * Not the same thing as [newRpcId], which names one HTTP call. This names the *message*: the host
+ * persists it on the message the prompt is accepted as, so a retry of the same message must carry
+ * the id it already had, and two different messages must never share one.
+ */
+fun newPromptRequestId(): String = UUID.randomUUID().toString()
+
 /** Encode a client-request envelope (POST /api/<method> body). */
 fun encodeEnvelope(request: ClientRequest): String =
     WireJson.encodeToString(ClientRequest.serializer(), request)

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SessionsDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SessionsDtos.kt
@@ -250,6 +250,14 @@ data class SessionSelectModelRequest(
 /** Request payload of `session.prompt`. */
 @Serializable
 data class SessionPromptRequest(
+    /**
+     * Identity of this one human message, minted by the sender before the call. Host-required.
+     *
+     * The host persists it on the exact message the prompt is accepted as, which is what lets a
+     * sender match its own optimistic echo to the message that came back. It is per *message*,
+     * not per call: a resend of the same message keeps its id, and a new message never reuses one.
+     */
+    @SerialName("requestId") val requestId: String,
     @SerialName("sessionId") val sessionId: String,
     /** mode maps 1:1 — queue→send, steer→steer. */
     @SerialName("mode") val mode: String,

--- a/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SubagentDtos.kt
+++ b/core/src/main/kotlin/com/labteto/dshmobile/core/wire/dto/SubagentDtos.kt
@@ -177,6 +177,13 @@ data class SubagentHistoryValue(
 /** Request payload of `subagent.prompt` (continuable children only). */
 @Serializable
 data class SubagentPromptRequest(
+    /**
+     * Identity of this one human message, minted by the sender before the call. Host-required.
+     *
+     * Carries the same `session-request-id` brand an ordinary session prompt does, so a child
+     * message and a session message share one identity vocabulary.
+     */
+    @SerialName("requestId") val requestId: String,
     @SerialName("parentSessionId") val parentSessionId: String,
     @SerialName("childSessionId") val childSessionId: String,
     @SerialName("mode") val mode: String = "continuable",

--- a/core/src/test/kotlin/com/labteto/dshmobile/core/wire/DshApiClientRemoteTest.kt
+++ b/core/src/test/kotlin/com/labteto/dshmobile/core/wire/DshApiClientRemoteTest.kt
@@ -3,7 +3,11 @@ package com.labteto.dshmobile.core.wire
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import kotlinx.coroutines.test.runTest
+import com.labteto.dshmobile.core.wire.dto.ContentBlock
 import com.labteto.dshmobile.core.wire.dto.EncodedImageAttachment
+import com.labteto.dshmobile.core.wire.dto.PromptContentPart
+import com.labteto.dshmobile.core.wire.dto.SessionPromptRequest
+import com.labteto.dshmobile.core.wire.dto.SubagentPromptRequest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -159,6 +163,70 @@ class DshApiClientRemoteTest {
 
         val commands = (result as RpcResult.Ok).value
         assertEquals(listOf("plan", "compact"), commands.map { it.name })
+    }
+
+    @Test
+    fun `a prompt carries the host's required requestId`() = runTest {
+        // Harness 0.1.2 made `requestId` a required field of the prompt request and validates the
+        // whole `request` object against a strict codec, so a client that omits it cannot send a
+        // message at all: the gateway answers `wire field "request" failed boundary validation`
+        // before any agent sees the text. Nothing in this repo sent one until this test existed.
+        val transport = RecordingTransport { _, body ->
+            val rpcId = Json.parseToJsonElement(body).jsonObject["rpcId"]!!.jsonPrimitive.content
+            ok(rpcId, """{"accepted":true}""")
+        }
+        val result = client(transport).sessionPrompt(
+            SessionPromptRequest(
+                requestId = "11111111-2222-3333-4444-555555555555",
+                sessionId = "session-7",
+                mode = "queue",
+                content = listOf(PromptContentPart.Text("hello")),
+                clientTimeZone = "Asia/Bangkok",
+            ),
+        )
+
+        assertEquals("/api/session/prompt", transport.lastPath)
+        val request = Json.parseToJsonElement(transport.lastBody!!)
+            .jsonObject["payload"]!!.jsonObject["args"]!!.jsonObject["request"]!!.jsonObject
+        assertEquals(
+            setOf("requestId", "sessionId", "mode", "content", "clientTimeZone"),
+            request.keys,
+        )
+        assertEquals("11111111-2222-3333-4444-555555555555", request["requestId"]!!.jsonPrimitive.content)
+        assertTrue((result as RpcResult.Ok).value.accepted)
+    }
+
+    @Test
+    fun `a subagent prompt carries one too`() = runTest {
+        val transport = RecordingTransport { _, body ->
+            val rpcId = Json.parseToJsonElement(body).jsonObject["rpcId"]!!.jsonPrimitive.content
+            ok(rpcId, """{"messageId":"m1"}""")
+        }
+        client(transport).subagentPrompt(
+            SubagentPromptRequest(
+                requestId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                parentSessionId = "parent-1",
+                childSessionId = "child-1",
+                content = listOf(ContentBlock.Text("carry on")),
+                clientTimeZone = "Asia/Bangkok",
+            ),
+        )
+
+        val request = Json.parseToJsonElement(transport.lastBody!!)
+            .jsonObject["payload"]!!.jsonObject["args"]!!.jsonObject["request"]!!.jsonObject
+        assertEquals("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", request["requestId"]!!.jsonPrimitive.content)
+        // The child prompt shares the session prompt's identity vocabulary, so the discriminator
+        // the host declares required rides along beside it rather than being assumed.
+        assertEquals("continuable", request["mode"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `each message is minted its own identity`() {
+        // Per message, not per call: two prompts must never claim to be the same message, or the
+        // host would persist one identity on two of them.
+        val ids = List(64) { newPromptRequestId() }
+        assertEquals(64, ids.toSet().size)
+        assertTrue(ids.all { it.isNotBlank() })
     }
 
     @Test

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -8,9 +8,10 @@ checked against.
 
 | DSH Mobile | Harness version | Status |
 |---|---|---|
-| 0.9.2 | 0.1.2-alpha.1 | Supported baseline |
-| 0.9.1 | 0.1.2-alpha.1 | |
-| 0.9.0 | 0.1.2-alpha.1 | |
+| 0.9.3 | 0.1.2-alpha.1 | Supported baseline |
+| 0.9.2 | 0.1.2-alpha.1 | Cannot send messages |
+| 0.9.1 | 0.1.2-alpha.1 | Cannot send messages |
+| 0.9.0 | 0.1.2-alpha.1 | Cannot send messages |
 | 0.8.0 | 0.1.1-rc.2 | Previous baseline |
 | 0.7.0 | 0.1.1-rc.2 | |
 | 0.6.0 | 0.1.1-rc.2 | |
@@ -92,6 +93,11 @@ a summary rather than an exhaustive list; `docs/PROTOCOL.md` carries the shapes.
   (`session.list` → `session/list`). Several calls that took a request object now
   take flat named arguments, because the gateway matches an args object against
   the host method's *parameter names*.
+- **Prompts carry an identity.** `session/prompt` and `subagents/prompt` gained a
+  required `requestId`, minted by the sender, one per human message; the host
+  persists it on the message the prompt is accepted as. It is checked inside the
+  request object rather than beside the other args, so leaving it out refuses
+  every send while the rest of the surface goes on working.
 - **One socket.** `/api/events.mux` and `/api/events.host` were replaced by
   `/api/remote.mux`, which multiplexes independently cancellable logical streams
   and, unlike its predecessors, is written to as well as read.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -38,6 +38,16 @@ chose:
   `session/list`'s sole argument is genuinely named `_request` — the host method
   ignores it, but the wire name is the parameter identifier verbatim.
 
+Key matching is only the first of two checks. An endpoint whose sole argument is
+`request` then decodes that object against a strict codec, which refuses a
+missing required field *after* the args themselves passed — and says so
+differently: `wire field "request" failed boundary validation`, under code
+`internal`, since a shape mismatch gets no code of its own. Both prompt
+endpoints turn on a field this client did not always send: `session/prompt` and
+`subagents/prompt` require a `requestId`, minted by the sender, one fresh id per
+human message, which the host persists on the message the prompt is accepted as.
+Omit it and every send fails while every other call still works.
+
 The namespaces this app uses: `session`, `workspace`, `directoryPicker`,
 `settings`, `credentials`, `llm`, `skills`, `subagents`, `agentPresets`, `goals`,
 `commands`, `fileReferences`, `pluginInventory`.

--- a/mock-harness/src/main/kotlin/com/labteto/dshmobile/mockharness/MockHarness.kt
+++ b/mock-harness/src/main/kotlin/com/labteto/dshmobile/mockharness/MockHarness.kt
@@ -43,6 +43,7 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * A scriptable stand-in for the DeepSeek Harness HTTP/WebSocket protocol.
@@ -101,6 +102,17 @@ class MockHarness(
     @Volatile
     var sessionExportBytes: ByteArray = ByteArray(0)
 
+    /**
+     * Every `request` object this harness accepted for `session/prompt`, in arrival order.
+     *
+     * Kept so a test can assert on what the client actually put on the wire — the identity it
+     * minted above all — rather than only on the call having succeeded.
+     */
+    val sessionPrompts: MutableList<JsonObject> = CopyOnWriteArrayList()
+
+    /** Every `request` object this harness accepted for `subagents/prompt`, in arrival order. */
+    val subagentPrompts: MutableList<JsonObject> = CopyOnWriteArrayList()
+
     private val normalizedTrustedHosts: Set<String> =
         trustedHosts.mapTo(mutableSetOf()) { normalizeHost(it) }
 
@@ -111,6 +123,28 @@ class MockHarness(
         // the Session Controller that serves it.
         on("session/canOpenWorkspacePath") { JsonPrimitive(true) }
         on("pluginInventory/list") { pluginInventoryValue() }
+        // Registered here rather than left to each test, because the point of holding these two to
+        // the host's required fields is to catch a client that stopped sending one — and a check
+        // only the tests that remember to ask for it get is a check that was not there when it
+        // mattered. A test that wants a different answer re-registers the endpoint as usual.
+        requestRemote(
+            "session",
+            "prompt",
+            required = setOf("requestId", "sessionId", "mode", "content"),
+            optional = setOf("clientTimeZone"),
+        ) { request ->
+            sessionPrompts.add(request)
+            buildJsonObject { put("accepted", true) }
+        }
+        requestRemote(
+            "subagents",
+            "prompt",
+            required = setOf("requestId", "parentSessionId", "childSessionId", "mode", "content"),
+            optional = setOf("clientTimeZone"),
+        ) { request ->
+            subagentPrompts.add(request)
+            buildJsonObject { put("messageId", UUID.randomUUID().toString()) }
+        }
     }
 
     /**
@@ -281,20 +315,78 @@ class MockHarness(
             if (missing.isEmpty() && unexpected.isEmpty()) {
                 handler(args)
             } else {
-                throw ArgumentsInvalid(argumentsInvalidMessage(missing, unexpected))
+                throw ArgumentsInvalid(argumentsInvalidMessage(endpoint, missing, unexpected))
             }
+        }
+    }
+
+    /**
+     * Registers a remote whose sole argument is `request`, held to the gateway's *boundary* rule.
+     *
+     * [remote] matches the args keys, which is one layer too shallow for an endpoint that takes a
+     * single request object: every such call passes `args` key matching and is then decoded
+     * against a strict codec, so a field missing from inside `request` is refused separately and
+     * with a different message. A mock that checked only the outer key set would happily accept a
+     * prompt the real host rejects, which is the exact gap that let a prompt without `requestId`
+     * ship green.
+     *
+     * Only [required] absences are refused. The codec is a zod object, which drops a key it does
+     * not declare rather than failing on it, so an unexpected field is not an error here the way
+     * an unexpected *arg* is.
+     *
+     * @param required every field the host declares without `?`.
+     * @param optional every field it declares with one; listed for the reader, not enforced.
+     * @param handler maps the validated request object to the remote's return value.
+     */
+    fun requestRemote(
+        namespace: String,
+        method: String,
+        required: Set<String>,
+        optional: Set<String> = emptySet(),
+        handler: (JsonObject) -> JsonElement,
+    ) {
+        val endpoint = "$namespace/$method"
+        require(optional.none { it in required }) {
+            "$endpoint: a field cannot be both required and optional"
+        }
+        remote(namespace, method, setOf("request")) { args ->
+            val request = args["request"] as? JsonObject
+                ?: throw BoundaryInvalid(boundaryInvalidMessage(endpoint, "request"))
+            // The refusal names the field that failed and nothing inside it: the gateway keeps
+            // boundary values out of its own message, so a mock that listed the missing keys
+            // would be handing the client a hint the real host withholds.
+            if (required.any { it !in request.keys }) {
+                throw BoundaryInvalid(boundaryInvalidMessage(endpoint, "request"))
+            }
+            handler(request)
         }
     }
 
     /** The gateway's `arguments-invalid` refusal, thrown out of a [remote] handler. */
     class ArgumentsInvalid(override val message: String) : RuntimeException(message)
 
-    private fun argumentsInvalidMessage(missing: List<String>, unexpected: List<String>): String {
+    /**
+     * The gateway's `input-invalid` refusal, thrown out of a [requestRemote] handler.
+     *
+     * Reaches the client as code `internal` like every other gateway failure: a shape mismatch
+     * gets no code of its own, which is precisely why a client must not send one to find out.
+     */
+    class BoundaryInvalid(override val message: String) : RuntimeException(message)
+
+    private fun boundaryInvalidMessage(endpoint: String, field: String): String =
+        "typert gateway: $endpoint: wire field \"$field\" failed boundary validation"
+
+    private fun argumentsInvalidMessage(
+        endpoint: String,
+        missing: List<String>,
+        unexpected: List<String>,
+    ): String {
         val clauses = buildList {
             if (missing.isNotEmpty()) add("missing " + missing.joinToString(", ") { "\"$it\"" })
             if (unexpected.isNotEmpty()) add("unexpected " + unexpected.joinToString(", ") { "\"$it\"" })
         }
-        return "args fields do not match the descriptor: " + clauses.joinToString("; ")
+        return "typert gateway: $endpoint: args fields do not match the descriptor: " +
+            clauses.joinToString("; ")
     }
 
     /**
@@ -535,6 +627,8 @@ class MockHarness(
                 // The gateway reports a refused args object as an ordinary thrown failure, which
                 // the RPC layer renders with code `internal` — a shape mismatch does not get its
                 // own error code, which is exactly why the client must not send one to find out.
+                respondJson(errorEnvelope(rpcId, "internal", invalid.message))
+            } catch (invalid: BoundaryInvalid) {
                 respondJson(errorEnvelope(rpcId, "internal", invalid.message))
             }
             failHandlers.containsKey(method) -> {


### PR DESCRIPTION
Fixes #12.

Sending any message to a harness 0.1.2 failed. Connecting, listing sessions, reading history and choosing a model all worked, so the app looked healthy right until you sent something — at which point the gateway answered `wire field "request" failed boundary validation` and the text never reached an agent. Ordinary sessions and continuable children alike.

## Cause

0.1.2 made `requestId` a required field of both prompt requests. It is an identity the sender mints, one per human message, which the host persists on the message the prompt is accepted as.

- `packages/api/session-controller/src/types.ts:319` — `readonly requestId: SessionRequestId`, no `?`
- `packages/subagent/subagent/src/control-types.ts:101` — `readonly requestId: SubagentPromptRequestId`, no `?`

Neither of this client's DTOs had the field, and neither call site minted one. Verified against the real 0.1.2-alpha.1 tree, not the issue text — the local harness checkout was 1079 commits behind and had to be fetched first.

## Fix

Both DTOs take `requestId` as a required constructor parameter with no default, so the compiler refuses any construction site that omits it. `SessionStore.promptContent()` and `promptSubagent()` mint one per send via a new `newPromptRequestId()`, which sits beside `newRpcId()` and is documented against it: that one names an HTTP call, this one names the message.

## Why CI stayed green through three releases

The mock harness matched an endpoint's outer argument keys and stopped there. A request object is checked twice — the args keys, then the object itself against a strict codec — and this bug lived in the second check. The mock also implemented neither prompt endpoint, so no test in the repo had ever sent a message.

Both endpoints are registered now, held to the host's required fields and refusing a missing one with the gateway's own message and error code. The suite sends real prompts through the real client against them over a socket. The regression test sends the pre-fix wire shape as a raw args object, since the typed request can no longer express it.

One deliberate limit: the mock refuses a missing required field but not an unknown one. The codec is a zod object, which drops a key it does not declare rather than failing on it, so enforcing that would be a guess. Said so in the doc comment.

## Also

- `docs/PROTOCOL.md` documented the args-key rule but stopped one layer short of where this failed; it now describes the second, stricter check.
- `docs/COMPATIBILITY.md` gains the change as a 0.1.2 bullet, and its support table marks 0.9.0–0.9.2 as unable to send messages.
- Version bumped to 0.9.3 with a changelog entry.

## Testing

302 unit tests pass across `:core`, `:mock-harness` and `:app`, including six new ones. `:app:assembleDebug` builds.

Not yet driven on an emulator against a live harness — worth doing before tagging, since that is how the last two releases' bugs were found.

Reported by @snailium, who traced it to both DTOs and confirmed against a live 0.1.2-alpha.1 that the same call succeeds with an id and fails without one.
